### PR TITLE
Refactorings

### DIFF
--- a/src/ast.rkt
+++ b/src/ast.rkt
@@ -89,7 +89,7 @@
                  `((,name . ,in) . ,(car neighs-vals)))
                ins))))))
 
-(define (pln x) (println x) x)
+(define (pln x) (pretty-print x) x)
 
 (define (top-order comp)
 

--- a/src/ast.rkt
+++ b/src/ast.rkt
@@ -1,6 +1,12 @@
-#lang racket
+#lang racket/base
 
 (require racket/hash
+         racket/bool
+         racket/sequence
+         racket/list
+         racket/pretty
+         racket/format
+         racket/match
          graph
          "component.rkt"
          "port.rkt")

--- a/src/ast.rkt
+++ b/src/ast.rkt
@@ -37,33 +37,33 @@
 (define (input-hash comp lst)
   (define empty-hash
     (make-immutable-hash
-     (map (lambda (x) `(,x . #f))
-          (append
-           (map car (get-edges (component-graph comp)))
-           (map (lambda (p)
-                  `(,(port-name p) . inf#))
-                (component-outs comp))))))
+      (map (lambda (x) `(,x . #f))
+           (append
+             (map car (get-edges (component-graph comp)))
+             (map (lambda (p)
+                    `(,(port-name p) . inf#))
+                  (component-outs comp))))))
   (clob-hash-union empty-hash
                    (make-immutable-hash (map (lambda (x) `((,(car x) . inf#) . ,(cdr x))) lst))))
 
 (define (transform comp inputs name)
   (if (findf (lambda (x) (equal? name (port-name x))) (component-ins comp))
-      (make-immutable-hash `(((,name . inf#) . ,(hash-ref inputs `(,name . inf#)))))
-      (begin
-        (let* ([sub (get-submod! comp name)]
-               [ins (map port-name (component-ins sub))])  ; XXX: deal with port widths
-          ;; (println (~v 'transform name ': inputs '-> ins))
-          (make-immutable-hash
-           (map (lambda (in)
-                  (define neighs
-                    (sequence->list (in-neighbors (transpose (component-graph comp)) `(,name . ,in))))
-                  (define filt-neighs-vals (filter-map (lambda (x) (hash-ref inputs x)) neighs))
-                  (define neighs-vals
-                    (if (empty? filt-neighs-vals)
-                        (map (lambda (x) (hash-ref inputs x)) neighs)
-                        filt-neighs-vals))
-                  `((,name . ,in) . ,(car neighs-vals)))
-                ins))))))
+    (make-immutable-hash `(((,name . inf#) . ,(hash-ref inputs `(,name . inf#)))))
+    (begin
+      (let* ([sub (get-submod! comp name)]
+             [ins (map port-name (component-ins sub))])  ; XXX: deal with port widths
+        ;; (println (~v 'transform name ': inputs '-> ins))
+        (make-immutable-hash
+          (map (lambda (in)
+                 (define neighs
+                   (sequence->list (in-neighbors (transpose (component-graph comp)) `(,name . ,in))))
+                 (define filt-neighs-vals (filter-map (lambda (x) (hash-ref inputs x)) neighs))
+                 (define neighs-vals
+                   (if (empty? filt-neighs-vals)
+                     (map (lambda (x) (hash-ref inputs x)) neighs)
+                     filt-neighs-vals))
+                 `((,name . ,in) . ,(car neighs-vals)))
+               ins))))))
 
 (define (pln x) (println x) x)
 
@@ -81,30 +81,30 @@
                        (lambda (x y)
                          (< (cdr x) (cdr y)))))
   (reverse
-   (car (foldl (lambda (x acc)
-                 (if (= (cdr x) (cdr acc))
-                     `(,(cons (cons (car x) (caar acc)) (cdar acc)) . ,(cdr acc))
-                     `(,(cons `(,(car x)) (car acc)) . ,(+ 1 (cdr acc)))))
-               '(() . -1)
-               sorted))))
+    (car (foldl (lambda (x acc)
+                  (if (= (cdr x) (cdr acc))
+                    `(,(cons (cons (car x) (caar acc)) (cdar acc)) . ,(cdr acc))
+                    `(,(cons `(,(car x)) (car acc)) . ,(+ 1 (cdr acc)))))
+                '(() . -1)
+                sorted))))
 
 (define (mint-inactive-hash comp name)
   (make-immutable-hash (map
-                        (lambda (x)
-                          `((,name . ,(port-name x)) . #f))
-                        (append
-                         (component-outs (get-submod! comp name))
-                         (filter-map
-                          (lambda (x) (and (equal? name (port-name x))
-                                           (port 'inf# (port-width x))))
-                          (component-outs comp))))))
+                         (lambda (x)
+                           `((,name . ,(port-name x)) . #f))
+                         (append
+                           (component-outs (get-submod! comp name))
+                           (filter-map
+                             (lambda (x) (and (equal? name (port-name x))
+                                              (port 'inf# (port-width x))))
+                             (component-outs comp))))))
 
 ;; creates a hash for the outputs of sub-component [name] in [comp]
 ;; that has values from [hsh]
 (define (mint-remembered-hash comp hsh name)
   (define base (mint-inactive-hash comp name))
   (make-immutable-hash
-   (hash-map base (lambda (k v) `(,k . ,(hash-ref hsh k))))))
+    (hash-map base (lambda (k v) `(,k . ,(hash-ref hsh k))))))
 
 (struct memory-tup (current sub-mem) #:transparent)
 ;; given a subcomponent (comp name) a state and memory,
@@ -115,15 +115,15 @@
   ;; change to ((port . val) ...)
   (define ins
     (make-immutable-hash
-     (hash-map state (lambda (k v) `(,(cdr k) . ,v)))))
+      (hash-map state (lambda (k v) `(,(cdr k) . ,v)))))
 
   ;; get the current submemory out of mem, creating one if
   ;; it doesn't exist
   (define sub-mem
     (if (hash-has-key? tot-mem name)
-        (hash-ref tot-mem name)
-        (memory-tup (make-immutable-hash)
-                    (make-immutable-hash))))
+      (hash-ref tot-mem name)
+      (memory-tup (make-immutable-hash)
+                  (make-immutable-hash))))
 
   ;; add memory to ins
   (define ins-p (hash-set ins 'mem# sub-mem))
@@ -131,16 +131,16 @@
   (let* ([proc (component-proc (get-submod! comp name))]
          [res (proc ins-p)]
          [sub-mem-p (if (hash-has-key? res 'mem#)
-                        (hash-ref res 'mem#)
-                        (memory-tup (make-immutable-hash)
-                                    (make-immutable-hash)))]
+                      (hash-ref res 'mem#)
+                      (memory-tup (make-immutable-hash)
+                                  (make-immutable-hash)))]
          ;; [mem (hash-ref res 'mem)]
          [res-wo-mem (hash-remove res 'mem#)])
     (values
-     (make-immutable-hash
-      (hash-map res-wo-mem
-                (lambda (k v) `((,name . ,k) . ,v))))
-     (hash-set tot-mem name sub-mem-p))))
+      (make-immutable-hash
+        (hash-map res-wo-mem
+                  (lambda (k v) `((,name . ,k) . ,v))))
+      (hash-set tot-mem name sub-mem-p))))
 
 (define (compute-step comp memory state inactive)
   ;; sort the components so that we evaluate things in the right order
@@ -150,9 +150,9 @@
   ;; function that goes through a given hashmap and sets all disabled wires to false
   (define (filt hsh)
     (make-immutable-hash
-     (hash-map hsh (lambda (k v) (if (member (car k) inactive)
-                                     `(,k . #f)
-                                     `(,k . ,v))))))
+      (hash-map hsh (lambda (k v) (if (member (car k) inactive)
+                                    `(,k . #f)
+                                    `(,k . ,v))))))
   ;; for every node in the graph, call submod-compute;
   ;; making sure to thread the state through properly
   (struct accum (state memory))
@@ -161,39 +161,39 @@
              (println (~a "<-<" sub "<-<"))
              (define res
                (if (member sub inactive)
-                   ; inactive (set sub to false in acc)
-                   (struct-copy accum acc
-                                [state
-                                 ; use save-union because other mods might
-                                 ; need values on the wires. we'll set them
-                                 ; to #f later
-                                 (save-hash-union (accum-state acc)
-                                                  (mint-inactive-hash comp sub))])
-                   ; active
-                   (let*-values
-                       (; remove disabled wires from memory, then union with state
-                        [(vals) (filt (save-hash-union
-                                       (memory-tup-current (accum-memory acc))
-                                       (accum-state acc)))]
-                        [(trans) (transform comp vals sub)]
-                        [(state-p sub-mem-p) ; pass in state and memory to submodule
-                         (submod-compute comp sub trans
-                                         (memory-tup-sub-mem (accum-memory acc)))]
-                        [(curr-mem-p) ; update this modules curr memory
-                         (if (component-activation-mode (get-submod! comp sub))
-                             ; is a register, update memory
-                             ; prefering first non-false then new vals
-                             (save-hash-union (memory-tup-current (accum-memory acc))
-                                              (mint-remembered-hash comp state-p sub))
-                             ; is not a register
-                             (memory-tup-current (accum-memory acc)))])
-                     (println inactive) (println (memory-tup-current (accum-memory acc)))
-                     (println vals) (println trans) (println state-p)
-                     (accum
-                      (save-hash-union (accum-state acc) state-p)
-                      (memory-tup curr-mem-p sub-mem-p))
-                     ;; (cons (save-hash-union (car acc) state-p) mem-p)
-                     )))
+                 ; inactive (set sub to false in acc)
+                 (struct-copy accum acc
+                              [state
+                                ; use save-union because other mods might
+                                ; need values on the wires. we'll set them
+                                ; to #f later
+                                (save-hash-union (accum-state acc)
+                                                 (mint-inactive-hash comp sub))])
+                 ; active
+                 (let*-values
+                   (; remove disabled wires from memory, then union with state
+                    [(vals) (filt (save-hash-union
+                                    (memory-tup-current (accum-memory acc))
+                                    (accum-state acc)))]
+                    [(trans) (transform comp vals sub)]
+                    [(state-p sub-mem-p) ; pass in state and memory to submodule
+                     (submod-compute comp sub trans
+                                     (memory-tup-sub-mem (accum-memory acc)))]
+                    [(curr-mem-p) ; update this modules curr memory
+                     (if (component-activation-mode (get-submod! comp sub))
+                       ; is a register, update memory
+                       ; prefering first non-false then new vals
+                       (save-hash-union (memory-tup-current (accum-memory acc))
+                                        (mint-remembered-hash comp state-p sub))
+                       ; is not a register
+                       (memory-tup-current (accum-memory acc)))])
+                   (println inactive) (println (memory-tup-current (accum-memory acc)))
+                   (println vals) (println trans) (println state-p)
+                   (accum
+                     (save-hash-union (accum-state acc) state-p)
+                     (memory-tup curr-mem-p sub-mem-p))
+                   ;; (cons (save-hash-union (car acc) state-p) mem-p)
+                   )))
              (println (~a ">->" sub ">->"))
              res)
            (accum state memory)
@@ -209,21 +209,21 @@
 
   ;; (define filled-mod filled)
   (values
-   filled-mod                ; state
-   (accum-memory filled)     ; memory
-   (map (lambda (x)          ; output
-          `(,(car x) . ,(hash-ref (accum-state filled) x)))
-        (map (lambda (x) `(,(port-name x) . inf#)) (component-outs comp)))))
+    filled-mod                ; state
+    (accum-memory filled)     ; memory
+    (map (lambda (x)          ; output
+           `(,(car x) . ,(hash-ref (accum-state filled) x)))
+         (map (lambda (x) `(,(port-name x) . inf#)) (component-outs comp)))))
 
 ;; XXX: fix the computation for parallel composition
 ;; run all computations in "parallel" and then merge the results
 
 (define-syntax-rule (if-valued condition tbranch fbranch)
   (if condition
-      (if (not (equal? condition 0))
-          tbranch
-          fbranch)
-      (void)))
+    (if (not (equal? condition 0))
+      tbranch
+      fbranch)
+    (void)))
 
 (struct ast-tuple (inactive state memory history) #:transparent)
 
@@ -271,40 +271,40 @@
          (println tup)
          (define res
            (if (empty? stmts)
-               ; no stmts, run compute-step
-               (let-values ([(st mem out)
-                             (compute-step comp
-                                           (ast-tuple-memory tup)
-                                           (ast-tuple-state tup)
-                                           (ast-tuple-inactive tup))])
-                 (struct-copy ast-tuple tup
-                              [state st]
-                              [memory mem]))
-               ; there are stmts! fold over them
-               (foldl (lambda (s acc)
-                        (let*-values ([(acc-p) (ast-step comp tup s)]
-                                      [(st mem out)
-                                       (compute-step comp
-                                                     (ast-tuple-memory acc-p)
-                                                     (ast-tuple-state acc-p)
-                                                     (ast-tuple-inactive acc-p))])
-                          (struct-copy ast-tuple acc
-                                       [inactive (remove-duplicates ; XXX why do we merge inactive?
-                                                  (append
+             ; no stmts, run compute-step
+             (let-values ([(st mem out)
+                           (compute-step comp
+                                         (ast-tuple-memory tup)
+                                         (ast-tuple-state tup)
+                                         (ast-tuple-inactive tup))])
+               (struct-copy ast-tuple tup
+                            [state st]
+                            [memory mem]))
+             ; there are stmts! fold over them
+             (foldl (lambda (s acc)
+                      (let*-values ([(acc-p) (ast-step comp tup s)]
+                                    [(st mem out)
+                                     (compute-step comp
+                                                   (ast-tuple-memory acc-p)
+                                                   (ast-tuple-state acc-p)
+                                                   (ast-tuple-inactive acc-p))])
+                        (struct-copy ast-tuple acc
+                                     [inactive (remove-duplicates ; XXX why do we merge inactive?
+                                                 (append
                                                    (ast-tuple-inactive acc-p)
                                                    (ast-tuple-inactive acc)))]
-                                       [state (merge-state st (ast-tuple-state acc))]
-                                       [memory mem ;; (merge-mem mem (ast-tuple-memory acc))
-                                               ])))
-                      ; the accum starts out with no state and no memory
-                      ; we never need to merge the starting state/mem with
-                      ; the state/mem calcuated in this step. rather, we
-                      ; use the starting state/mem to compute the new state/mem
-                      ; and then merge those with each other and pass those on
-                      (struct-copy ast-tuple tup
-                                   [state (make-immutable-hash)]
-                                   [memory (memory-tup (make-immutable-hash) (make-immutable-hash))])
-                      stmts)))
+                                     [state (merge-state st (ast-tuple-state acc))]
+                                     [memory mem ;; (merge-mem mem (ast-tuple-memory acc))
+                                             ])))
+                    ; the accum starts out with no state and no memory
+                    ; we never need to merge the starting state/mem with
+                    ; the state/mem calcuated in this step. rather, we
+                    ; use the starting state/mem to compute the new state/mem
+                    ; and then merge those with each other and pass those on
+                    (struct-copy ast-tuple tup
+                                 [state (make-immutable-hash)]
+                                 [memory (memory-tup (make-immutable-hash) (make-immutable-hash))])
+                    stmts)))
          (println tup)
          (println res)
          (println (ast-tuple-inactive res))
@@ -320,7 +320,7 @@
               tup
               stmts)]
       [(deact-stmt mods) (ast-tuple (remove-duplicates
-                                     (append mods inactive))
+                                      (append mods inactive))
                                     state
                                     memory
                                     history)]
@@ -330,8 +330,8 @@
                   (ast-step comp tup fbranch))]
       [(ifen-stmt condition tbranch fbranch)
        (if (hash-ref state condition)
-           (ast-step comp tup tbranch)
-           (ast-step comp tup fbranch))]
+         (ast-step comp tup tbranch)
+         (ast-step comp tup fbranch))]
       [(while-stmt condition body)
        (if-valued (hash-ref state condition)
                   (begin
@@ -348,8 +348,8 @@
 ;; (define comp (simp))
 ;; (define inputs '((a . 10) (b . 4)))
 (define (compute comp inputs #:memory [mem (memory-tup
-                                            (make-immutable-hash)
-                                            (make-immutable-hash))])
+                                             (make-immutable-hash)
+                                             (make-immutable-hash))])
   (define ast (component-control comp))
   (define state (input-hash comp inputs))
   (println "================")
@@ -359,11 +359,11 @@
   (define st-mem
     (struct-copy memory-tup mem
                  [current
-                  (clob-hash-union
-                   (make-immutable-hash
-                    (map (lambda (x) `((,(car x) . inf#) . ,(cdr x)))
-                         inputs))
-                   (memory-tup-current mem))]))
+                   (clob-hash-union
+                     (make-immutable-hash
+                       (map (lambda (x) `((,(car x) . inf#) . ,(cdr x)))
+                            inputs))
+                     (memory-tup-current mem))]))
   (print "st-mem ")
   (println st-mem)
   (define result (ast-step comp (ast-tuple '() state st-mem '()) ast))

--- a/src/component.rkt
+++ b/src/component.rkt
@@ -1,7 +1,11 @@
-#lang racket
+#lang racket/base
+
 (require graph
          racket/hash
+         racket/list
+         racket/match
          "port.rkt")
+
 (provide keyword-lambda
          (struct-out component)
          transform-control

--- a/src/constraint.rkt
+++ b/src/constraint.rkt
@@ -1,4 +1,5 @@
-#lang racket
+#lang racket/base
+
 (provide (struct-out equal-constraint)
          (struct-out cond-constraint)
          (struct-out equal-computation)

--- a/src/futil-prims.rkt
+++ b/src/futil-prims.rkt
@@ -1,6 +1,8 @@
-#lang racket
+#lang racket/base
+
 (require "component.rkt"
          "port.rkt")
+
 (provide comp/id
          comp/reg
          comp/add

--- a/src/futil-syntax.rkt
+++ b/src/futil-syntax.rkt
@@ -4,8 +4,10 @@
          "component.rkt"
          "ast.rkt"
          racket/format)
+
 (require (for-syntax racket/base
                      syntax/parse))
+
 (provide define/module)
 
 ;; simple macro that allows you to pass in components instead of

--- a/src/futil.rkt
+++ b/src/futil.rkt
@@ -1,4 +1,5 @@
-#lang racket
+#lang racket/base
+
 (require "ast.rkt"
          "futil-syntax.rkt"
          "futil-prims.rkt"

--- a/src/port.rkt
+++ b/src/port.rkt
@@ -1,4 +1,7 @@
-#lang racket
+#lang racket/base
+
+(require racket/match)
+
 (provide (struct-out port)
          infinite-port?
          find-port

--- a/src/vizualizer.rkt
+++ b/src/vizualizer.rkt
@@ -1,5 +1,7 @@
 #lang racket/gui
+
 (require graph)
+
 (require racket/gui/base
          mrlib/graph
          "component.rkt"


### PR DESCRIPTION
Some quick refactoring using magic racket stuff. Notes

- `match-define` (and other functions in `racket/match`) are super useful for destructuring any (and I do mean any) kind of data. Worth reading up on.
- `begin` is inconsistently used by Racket. Always worth checking if you actually need to use it (for example match branches don't!)
- `racket/base` loads faster than racket. However, macro heavy files are annoying to switch to `racket/base`.