### PR TITLE
Backend CLI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,3 +28,8 @@ jobs:
       with:
         command: fmt
         args: -- --check
+    - name: Run clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: -- --deny warnings

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ benchmarks/*.futil
 *.out
 *.run*
 Cargo.lock
-target/*
+target
 *.bak
 .DS_Store
 *.png

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Samuel Thomas <sgt43@cornell.edu>", "Kenneth Fang <kwf37@cornell.edu>"]
 edition = "2018"
 build = false
-# build = "build.rs"
 
 [dependencies]
 structopt = "~0.3"
@@ -15,11 +14,9 @@ sexpy = "~0.5"
 itertools = "~0.9"
 bumpalo = "3.2.0"
 atty = "~0.2"
+strum = "0.18.0"
+strum_macros = "0.18.0"
 
 [dependencies.pretty]
 version = "~0.9"
 features = ["termcolor"]
-
-# [build-dependencies]
-# clap = "2.33"
-# structopt = "~0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ build = false
 [dependencies]
 structopt = "~0.3"
 quickcheck = "0.9.0"
-petgraph = "~0.4"
+petgraph = "~0.5"
 better-panic = "~0.2"
 sexpy = "~0.5"
-itertools = "~0.7"
+itertools = "~0.9"
 bumpalo = "3.2.0"
 atty = "~0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ sexpy = "~0.5"
 itertools = "~0.9"
 bumpalo = "3.2.0"
 atty = "~0.2"
-strum = "0.18.0"
-strum_macros = "0.18.0"
 
 [dependencies.pretty]
 version = "~0.9"

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -5,11 +5,13 @@ use pretty::termcolor::ColorSpec;
 use pretty::RcDoc;
 
 /// All backends must implement this trait.
+/// `Backend::name` returns the name of this backend.
 /// `Backend::validate` should return `Ok(())` if the
 /// program is in the expected form and `Err(...)` otherwise.
 /// `Backend::emit` should convert the program to a formted string
 /// `Backend::run` is the composition of these two functions.
 pub trait Backend {
+    fn name() -> &'static str;
     fn validate(prog: &context::Context) -> Result<(), errors::Error>;
     fn emit(prog: &context::Context) -> Result<(), errors::Error>;
     fn run(prog: &context::Context) -> Result<(), errors::Error> {

--- a/src/backend/verilog/gen.rs
+++ b/src/backend/verilog/gen.rs
@@ -10,6 +10,10 @@ use pretty::RcDoc as D;
 pub struct VerilogBackend {}
 
 impl Backend for VerilogBackend {
+    fn name() -> &'static str {
+        "verilog"
+    }
+
     fn validate(ctx: &context::Context) -> Result<(), errors::Error> {
         let prog: ast::NamespaceDef = ctx.clone().into();
         for comp in &prog.components {

--- a/src/backend/verilog/gen.rs
+++ b/src/backend/verilog/gen.rs
@@ -53,7 +53,7 @@ impl Emitable for ast::ComponentDef {
             .append(D::line())
             .append(colors::define(D::text("module")))
             .append(D::space())
-            .append(&self.name)
+            .append(self.name.as_ref())
             .append(D::line())
             .append(parens(
                 D::line()
@@ -75,7 +75,7 @@ impl Emitable for ast::ComponentDef {
             .append(D::line())
             .append(colors::define(D::text("endmodule")))
             .append(D::space())
-            .append(format!("// end {}", &self.name))
+            .append(format!("// end {}", self.name.as_ref()))
     }
 }
 
@@ -102,7 +102,7 @@ impl Emitable for ast::Portdef {
             .append(D::space())
             .append(bit_width(self.width))
             .append(D::space())
-            .append(&self.name)
+            .append(self.name.as_ref())
     }
 }
 
@@ -147,7 +147,8 @@ fn wire_string<'a>(
     if !dests.is_empty() {
         let dest_comment =
             D::text("// ").append(D::intersperse(dests, D::text(", ")));
-        let wire_name = format!("{}${}", &name, &portdef.name);
+        let wire_name =
+            format!("{}${}", &name.to_string(), &portdef.name.to_string());
         Some(
             colors::keyword(D::text("wire"))
                 .append(D::space())
@@ -209,7 +210,7 @@ fn subcomponent_sig<'a>(
     structure: &ast::Structure,
 ) -> D<'a, ColorSpec> {
     use ast::Structure;
-    let (name, params): (&str, &[u64]) = match structure {
+    let (name, params): (&ast::Id, &[u64]) = match structure {
         Structure::Decl { data } => (&data.component, &[]),
         Structure::Std { data } => (&data.instance.name, &data.instance.params),
         Structure::Wire { .. } => {
@@ -245,8 +246,11 @@ fn signature_connections<'a>(
             comp.structure
                 .connected_from(idx, portdef.name.to_string())
                 .map(move |(src, edge)| {
-                    let wire_name =
-                        format!("{}${}", &src.get_name(), &edge.src);
+                    let wire_name = format!(
+                        "{}${}",
+                        &src.get_name().to_string(),
+                        &edge.src
+                    );
                     D::text(".")
                         .append(colors::port(D::text(portdef.name.to_string())))
                         .append(parens(colors::ident(D::text(wire_name))))
@@ -260,7 +264,8 @@ fn signature_connections<'a>(
             .count()
             > 0
         {
-            let wire_name = format!("{}${}", &name, &portdef.name);
+            let wire_name =
+                format!("{}${}", &name.to_string(), &portdef.name.to_string());
             Some(
                 D::text(".")
                     .append(colors::port(D::text(portdef.name.to_string())))

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,9 +1,12 @@
 use crate::backend::{traits::Backend, verilog::gen};
 use crate::errors;
 use crate::lang::context;
+use itertools::Itertools;
 use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::StructOpt;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 
 // Definition of the command line interface. Uses the `structopt` derive macro
 #[derive(StructOpt, Debug)]
@@ -33,7 +36,7 @@ pub struct Opts {
 
 // ================== Backend Variant and Parsing ===================== //
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, EnumIter)]
 pub enum BackendOpt {
     Verilog,
     None,
@@ -46,7 +49,14 @@ impl FromStr for BackendOpt {
         match s {
             "verilog" => Ok(Self::Verilog),
             "none" => Ok(Self::None),
-            x => Err(format!("{} is not a valid backend.", x)),
+            x => {
+                let backends =
+                    BackendOpt::iter().map(|v| v.to_string()).join(", ");
+                Err(format!(
+                    "`{}` is not a valid backend.\nValid backends: {}",
+                    x, backends
+                ))
+            }
         }
     }
 }

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -36,6 +36,7 @@ pub struct Opts {
 
 // ================== Backend Variant and Parsing ===================== //
 
+/// Enumeration of valid backends
 #[derive(Debug, EnumIter)]
 pub enum BackendOpt {
     Verilog,
@@ -61,6 +62,7 @@ impl FromStr for BackendOpt {
     }
 }
 
+/// Convert `BackendOpt` to a string
 impl ToString for BackendOpt {
     fn to_string(&self) -> String {
         match self {
@@ -72,6 +74,7 @@ impl ToString for BackendOpt {
 }
 
 impl BackendOpt {
+    /// Given a context, calls the backend corresponding to the `BackendOpt` variant
     pub fn run(&self, context: &context::Context) -> Result<(), errors::Error> {
         match self {
             BackendOpt::Verilog => gen::VerilogBackend::run(&context),

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,7 +1,11 @@
+use crate::backend::{traits::Backend, verilog::gen};
+use crate::errors;
+use crate::lang::context;
 use std::path::PathBuf;
+use std::str::FromStr;
 use structopt::StructOpt;
 
-/// Definition of the command line interface. Uses the `structopt` derive macro
+// Definition of the command line interface. Uses the `structopt` derive macro
 #[derive(StructOpt, Debug)]
 #[structopt(
     name = env!("CARGO_PKG_NAME"),
@@ -21,4 +25,47 @@ pub struct Opts {
     /// Enable debug mode output.
     #[structopt(short = "d", long = "debug")]
     pub enable_debug: bool,
+
+    /// Select a backend.
+    #[structopt(short = "b", long = "backend", default_value = "verilog")]
+    pub backend: BackendOpt,
+}
+
+// ================== Backend Variant and Parsing ===================== //
+
+#[derive(Debug, StructOpt)]
+pub enum BackendOpt {
+    Verilog,
+    None,
+}
+
+/// Command line parsing for the Backend enum
+impl FromStr for BackendOpt {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "verilog" => Ok(Self::Verilog),
+            "none" => Ok(Self::None),
+            x => Err(format!("{} is not a valid backend.", x)),
+        }
+    }
+}
+
+impl ToString for BackendOpt {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Verilog => "verilog",
+            Self::None => "none",
+        }
+        .to_string()
+    }
+}
+
+impl BackendOpt {
+    pub fn run(&self, context: &context::Context) -> Result<(), errors::Error> {
+        match self {
+            BackendOpt::Verilog => gen::VerilogBackend::run(&context),
+            BackendOpt::None => Ok(()),
+        }
+    }
 }

--- a/src/lang/ast.rs
+++ b/src/lang/ast.rs
@@ -11,7 +11,43 @@ use std::path::PathBuf;
 // XXX(sam) Add location information to this type so that we can print
 // them out nicely
 /// Represents an identifier in a Futil program
-pub type Id = String;
+#[derive(Clone, Debug, Hash, Sexpy, PartialEq, Eq)]
+#[sexpy(nohead, nosurround)]
+pub struct Id {
+    id: String,
+}
+
+/* =================== Impls for Id to make them easier to use ============== */
+impl ToString for Id {
+    fn to_string(&self) -> String {
+        self.id.clone()
+    }
+}
+
+impl AsRef<str> for Id {
+    fn as_ref(&self) -> &str {
+        &self.id
+    }
+}
+
+impl From<&str> for Id {
+    fn from(s: &str) -> Self {
+        Id { id: s.to_string() }
+    }
+}
+
+impl From<String> for Id {
+    fn from(s: String) -> Self {
+        Id { id: s }
+    }
+}
+
+impl PartialEq<str> for Id {
+    fn eq(&self, other: &str) -> bool {
+        self.id == other
+    }
+}
+/* =================== Impls for Id to make them easier to use ============== */
 
 /// Parses a pathbuf into a NamespaceDef
 pub fn parse_file(file: &PathBuf) -> Result<NamespaceDef, Error> {
@@ -72,7 +108,7 @@ pub struct Signature {
 
 impl Signature {
     pub fn has_input(&self, name: &str) -> bool {
-        self.inputs.iter().any(|e| e.name == name)
+        self.inputs.iter().any(|e| &e.name == name)
     }
     // pub fn new(inputs: &[(&str, u64)], outputs: &[(&str, u64)]) -> Self {
     //     Signature {
@@ -93,7 +129,7 @@ pub struct Portdef {
 impl From<(&str, u64)> for Portdef {
     fn from((name, width): (&str, u64)) -> Self {
         Portdef {
-            name: name.to_string(),
+            name: name.into(),
             width,
         }
     }
@@ -113,7 +149,7 @@ pub enum Port {
 }
 
 impl Port {
-    pub fn port_name(&self) -> &str {
+    pub fn port_name(&self) -> &Id {
         match self {
             Port::Comp { port, .. } => port,
             Port::This { port } => port,
@@ -198,18 +234,21 @@ pub struct Par {
     pub stmts: Vec<Control>,
 }
 
-// If control node in the AST.
+/// If control node in the AST.
 #[derive(Debug, Clone, Hash, Sexpy)]
 #[sexpy(nosurround)]
 pub struct If {
-    // Port that connects the conditional check.
+    /// Port that connects the conditional check.
     pub port: Port,
+
     #[sexpy(surround)]
-    // Modules that need to be enabled to send signal on `port`.
+    /// Modules that need to be enabled to send signal on `port`.
     pub cond: Vec<Id>,
-    // Control for the true branch.
+
+    /// Control for the true branch.
     pub tbranch: Box<Control>,
-    // Control for the true branch.
+
+    /// Control for the true branch.
     pub fbranch: Box<Control>,
 }
 

--- a/src/lang/ast.rs
+++ b/src/lang/ast.rs
@@ -234,21 +234,21 @@ pub struct Par {
     pub stmts: Vec<Control>,
 }
 
-/// If control node in the AST.
+// If control node in the AST.
 #[derive(Debug, Clone, Hash, Sexpy)]
 #[sexpy(nosurround)]
 pub struct If {
-    /// Port that connects the conditional check.
+    // Port that connects the conditional check.
     pub port: Port,
 
     #[sexpy(surround)]
-    /// Modules that need to be enabled to send signal on `port`.
+    // Modules that need to be enabled to send signal on `port`.
     pub cond: Vec<Id>,
 
-    /// Control for the true branch.
+    // Control for the true branch.
     pub tbranch: Box<Control>,
 
-    /// Control for the true branch.
+    // Control for the true branch.
     pub fbranch: Box<Control>,
 }
 

--- a/src/lang/component.rs
+++ b/src/lang/component.rs
@@ -19,12 +19,12 @@ pub struct Component {
 /// Methods over Components. Only define functions that cannot be methods
 /// on `Control`, `Signature`, or `Structure`.
 impl Component {
-    pub fn from_signature(name: &str, sig: ast::Signature) -> Self {
+    pub fn from_signature<S: AsRef<str>>(name: S, sig: ast::Signature) -> Self {
         let mut graph = StructureGraph::new();
         graph.add_signature(&sig);
 
         Component {
-            name: name.to_string(),
+            name: name.as_ref().into(),
             signature: sig,
             control: ast::Control::empty(),
             structure: graph,

--- a/src/lang/context.rs
+++ b/src/lang/context.rs
@@ -83,9 +83,9 @@ impl Context {
             .collect()
     }
 
-    pub fn instantiate_primitive(
+    pub fn instantiate_primitive<S: AsRef<str>>(
         &self,
-        name: &str,
+        name: S,
         id: &ast::Id,
         params: &[u64],
     ) -> Result<Component, errors::Error> {
@@ -108,12 +108,15 @@ impl Context {
 
 impl Into<ast::NamespaceDef> for Context {
     fn into(self) -> ast::NamespaceDef {
-        let name = "placeholder".to_string();
+        let name = "placeholder";
         let mut components: Vec<ast::ComponentDef> = vec![];
         for comp in self.definitions.borrow().values() {
             components.push(comp.clone().into())
         }
-        ast::NamespaceDef { name, components }
+        ast::NamespaceDef {
+            name: name.into(),
+            components,
+        }
     }
 }
 
@@ -158,9 +161,7 @@ impl LibraryContext {
                 let outputs = outputs_res?;
                 Ok(ast::Signature { inputs, outputs })
             }
-            None => {
-                Err(errors::Error::SignatureResolutionFailed(id.to_string()))
-            }
+            None => Err(errors::Error::SignatureResolutionFailed(id.clone())),
         }
     }
 }

--- a/src/lang/library/ast.rs
+++ b/src/lang/library/ast.rs
@@ -24,7 +24,7 @@ pub struct Library {
 #[derive(Sexpy, Clone, Debug)]
 #[sexpy(head = "define/prim")]
 pub struct Primitive {
-    pub name: String,
+    pub name: Id,
     #[sexpy(surround)]
     pub params: Vec<Id>,
     pub signature: ParamSignature,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ mod lang;
 mod passes;
 mod utils;
 
-use crate::backend::traits::Backend;
 use crate::cmdline::Opts;
 use crate::lang::context;
 use crate::passes::visitor::Visitor;
@@ -23,9 +22,9 @@ fn main() -> Result<(), errors::Error> {
     passes::lat_insensitive::LatencyInsenstive::do_pass_default(&context)?;
     passes::redundant_par::RedundantPar::do_pass_default(&context)?;
     passes::remove_if::RemoveIf::do_pass_default(&context)?;
-
     passes::collapse_seq::CollapseSeq::do_pass_default(&context)?;
-    backend::verilog::gen::VerilogBackend::run(&context)?;
+
+    opts.backend.run(&context)?;
 
     Ok(())
 }

--- a/src/passes/redundant_par.rs
+++ b/src/passes/redundant_par.rs
@@ -21,7 +21,7 @@ impl Visitor for RedundantPar {
         _comp: &mut Component,
         _c: &Context,
     ) -> VisResult {
-        let mut enabled: Vec<String> = vec![];
+        let mut enabled: Vec<ast::Id> = vec![];
         for con in &s.stmts {
             match con {
                 ast::Control::Enable { data } => {

--- a/src/passes/remove_if.rs
+++ b/src/passes/remove_if.rs
@@ -55,14 +55,11 @@ impl Visitor for RemoveIf {
         let add_structure_fbranch =
             |this_comp: &mut Component, en_comp: &ast::Id| {
                 // XXX(sam) randomly generate this name
-                let name = format!("{}_not", en_comp);
-                let neg_comp = ctx.instantiate_primitive(
-                    &name,
-                    &"std_not".to_string(), // XXX(sam) this is silly
-                    &[1],
-                )?;
+                let name = format!("{}_not", en_comp.to_string());
+                let neg_comp =
+                    ctx.instantiate_primitive(&name, &"std_not".into(), &[1])?;
                 let neg = this_comp.structure.add_primitive(
-                    &name,
+                    &name.into(),
                     "std_not",
                     &neg_comp,
                     &[1],
@@ -99,7 +96,7 @@ impl Visitor for RemoveIf {
                 let mut comps_seq = vec![];
                 comps_seq.push(ast::Control::enable(con.cond.clone()));
 
-                let branch_control: Vec<String> = tbranch
+                let branch_control: Vec<ast::Id> = tbranch
                     .comps
                     .clone()
                     .into_iter()
@@ -116,11 +113,11 @@ impl Visitor for RemoveIf {
 
 fn resolve_signature<'a>(
     this_comp: &'a mut Component,
-    en_comp: &str,
+    en_comp: &ast::Id,
 ) -> Result<&'a ast::Signature, errors::Error> {
     let sig = this_comp.resolved_sigs.get(en_comp);
     match sig {
         Some(sig) => Ok(sig),
-        None => Err(errors::Error::UndefinedComponent(en_comp.to_string())),
+        None => Err(errors::Error::UndefinedComponent(en_comp.clone())),
     }
 }


### PR DESCRIPTION
Addresses issue #68 by adding a cmdline option to select which backend to use. 
The available backends are specified by `cmdline::BackendOpt` and the corresponding
`FromStr` and `ToString` trait implementations for it. For now, the backend names
are specified in `cmdline.rs` rather than in the backends directly.
