### PR TITLE
Static pass naming

### DIFF
--- a/calyx/src/passes/collapse_seq.rs
+++ b/calyx/src/passes/collapse_seq.rs
@@ -1,6 +1,6 @@
 use crate::lang::component::Component;
 use crate::lang::{ast, context::Context};
-use crate::passes::visitor::{Action, VisResult, Visitor};
+use crate::passes::visitor::{Action, Named, VisResult, Visitor};
 
 /// Pass that collapses
 ///(seq
@@ -18,11 +18,17 @@ use crate::passes::visitor::{Action, VisResult, Visitor};
 #[derive(Default)]
 pub struct CollapseSeq {}
 
-impl Visitor for CollapseSeq {
-    fn name(&self) -> String {
-        "remove redudant seq".to_string()
+impl Named for CollapseSeq {
+    fn name() -> &'static str {
+        "collapse-seq"
     }
 
+    fn description() -> &'static str {
+        "removes redudant seq statements"
+    }
+}
+
+impl Visitor for CollapseSeq {
     // use finish_seq so that we collapse things on the way
     // back up the tree and potentially catch more cases
     fn finish_seq(

--- a/calyx/src/passes/lat_insensitive.rs
+++ b/calyx/src/passes/lat_insensitive.rs
@@ -1,5 +1,5 @@
 use crate::lang::{component::Component, context::Context};
-use crate::passes::visitor::{Action, VisResult, Visitor};
+use crate::passes::visitor::{Action, Named, VisResult, Visitor};
 
 pub struct LatencyInsenstive {}
 
@@ -9,11 +9,17 @@ impl Default for LatencyInsenstive {
     }
 }
 
-impl Visitor for LatencyInsenstive {
-    fn name(&self) -> String {
-        "Latency Insenstive".to_string()
+impl Named for LatencyInsenstive {
+    fn name() -> &'static str {
+        "latency-insenstive"
     }
 
+    fn description() -> &'static str {
+        "Added a latency insenstive interface to all top level components"
+    }
+}
+
+impl Visitor for LatencyInsenstive {
     fn start(&mut self, comp: &mut Component, _c: &Context) -> VisResult {
         comp.add_input(("valid", 1));
         comp.add_output(("ready", 1));

--- a/calyx/src/passes/redundant_par.rs
+++ b/calyx/src/passes/redundant_par.rs
@@ -1,17 +1,23 @@
 use crate::lang::component::Component;
 use crate::lang::{ast, context::Context};
-use crate::passes::visitor::{Action, VisResult, Visitor};
+use crate::passes::visitor::{Action, Named, VisResult, Visitor};
 
 /// Pass that collapses `(par (enable A B) (enable C D))`
 /// into `(enable A B C D)`
 #[derive(Default)]
 pub struct RedundantPar {}
 
-impl Visitor for RedundantPar {
-    fn name(&self) -> String {
-        "remove redudant par".to_string()
+impl Named for RedundantPar {
+    fn name() -> &'static str {
+        "redudant-par"
     }
 
+    fn description() -> &'static str {
+        "removes redudant par statements"
+    }
+}
+
+impl Visitor for RedundantPar {
     // use finish_par so that we collapse things on the way
     // back up the tree and potentially catch more cases
     fn finish_par(

--- a/calyx/src/passes/remove_if.rs
+++ b/calyx/src/passes/remove_if.rs
@@ -1,6 +1,6 @@
 use crate::errors;
 use crate::lang::{ast, component::Component, context::Context};
-use crate::passes::visitor::{Action, VisResult, Visitor};
+use crate::passes::visitor::{Action, Named, VisResult, Visitor};
 
 /// Pass that removes if statments where both branches are enables:
 /// ```lisp
@@ -18,11 +18,17 @@ use crate::passes::visitor::{Action, VisResult, Visitor};
 #[derive(Default)]
 pub struct RemoveIf {}
 
-impl Visitor for RemoveIf {
-    fn name(&self) -> String {
-        "remove simple if statements".to_string()
+impl Named for RemoveIf {
+    fn name() -> &'static str {
+        "remove-if"
     }
 
+    fn description() -> &'static str {
+        "remove simple if statements"
+    }
+}
+
+impl Visitor for RemoveIf {
     fn finish_if(
         &mut self,
         con: &mut ast::If,


### PR DESCRIPTION
This pass moves pass naming into a separate trait called `Named`.
This allows the naming functions to have type `fn() -> &'static str` instead
of `fn(&self) -> String`. This allows access to the name and description of a
pass without first instantiating the associated pass struct.
