### PR TITLE
Remove visitor control mutability

### DIFF
--- a/calyx/src/passes/collapse_seq.rs
+++ b/calyx/src/passes/collapse_seq.rs
@@ -27,7 +27,7 @@ impl Visitor for CollapseSeq {
     // back up the tree and potentially catch more cases
     fn finish_seq(
         &mut self,
-        s: &mut ast::Seq,
+        s: &ast::Seq,
         _comp: &mut Component,
         _c: &Context,
     ) -> VisResult {

--- a/calyx/src/passes/redundant_par.rs
+++ b/calyx/src/passes/redundant_par.rs
@@ -16,7 +16,7 @@ impl Visitor for RedundantPar {
     // back up the tree and potentially catch more cases
     fn finish_par(
         &mut self,
-        s: &mut ast::Par,
+        s: &ast::Par,
         _comp: &mut Component,
         _c: &Context,
     ) -> VisResult {

--- a/calyx/src/passes/remove_if.rs
+++ b/calyx/src/passes/remove_if.rs
@@ -25,7 +25,7 @@ impl Visitor for RemoveIf {
 
     fn finish_if(
         &mut self,
-        con: &mut ast::If,
+        con: &ast::If,
         this_comp: &mut Component,
         ctx: &Context,
     ) -> VisResult {

--- a/calyx/src/passes/visitor.rs
+++ b/calyx/src/passes/visitor.rs
@@ -103,7 +103,7 @@ pub trait Visitor {
 
     fn start_seq(
         &mut self,
-        _s: &mut Seq,
+        _s: &Seq,
         _comp: &mut Component,
         _c: &Context,
     ) -> VisResult {
@@ -112,7 +112,7 @@ pub trait Visitor {
 
     fn finish_seq(
         &mut self,
-        _s: &mut Seq,
+        _s: &Seq,
         _comp: &mut Component,
         _c: &Context,
     ) -> VisResult {
@@ -121,7 +121,7 @@ pub trait Visitor {
 
     fn start_par(
         &mut self,
-        _s: &mut Par,
+        _s: &Par,
         _comp: &mut Component,
         _c: &Context,
     ) -> VisResult {
@@ -130,7 +130,7 @@ pub trait Visitor {
 
     fn finish_par(
         &mut self,
-        _s: &mut Par,
+        _s: &Par,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {
@@ -139,7 +139,7 @@ pub trait Visitor {
 
     fn start_if(
         &mut self,
-        _s: &mut If,
+        _s: &If,
         _comp: &mut Component,
         _c: &Context,
     ) -> VisResult {
@@ -148,7 +148,7 @@ pub trait Visitor {
 
     fn finish_if(
         &mut self,
-        _s: &mut If,
+        _s: &If,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {
@@ -157,7 +157,7 @@ pub trait Visitor {
 
     fn start_while(
         &mut self,
-        _s: &mut While,
+        _s: &While,
         _comp: &mut Component,
         _c: &Context,
     ) -> VisResult {
@@ -166,7 +166,7 @@ pub trait Visitor {
 
     fn finish_while(
         &mut self,
-        _s: &mut While,
+        _s: &While,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {
@@ -175,7 +175,7 @@ pub trait Visitor {
 
     fn start_print(
         &mut self,
-        _s: &mut Print,
+        _s: &Print,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {
@@ -184,7 +184,7 @@ pub trait Visitor {
 
     fn finish_print(
         &mut self,
-        _s: &mut Print,
+        _s: &Print,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {
@@ -193,7 +193,7 @@ pub trait Visitor {
 
     fn start_enable(
         &mut self,
-        _s: &mut Enable,
+        _s: &Enable,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {
@@ -202,7 +202,7 @@ pub trait Visitor {
 
     fn finish_enable(
         &mut self,
-        _s: &mut Enable,
+        _s: &Enable,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {
@@ -211,7 +211,7 @@ pub trait Visitor {
 
     fn start_empty(
         &mut self,
-        _s: &mut Empty,
+        _s: &Empty,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {
@@ -220,7 +220,7 @@ pub trait Visitor {
 
     fn finish_empty(
         &mut self,
-        _s: &mut Empty,
+        _s: &Empty,
         _comp: &mut Component,
         _x: &Context,
     ) -> VisResult {


### PR DESCRIPTION
Changes all the visitor functions to take immutable references
to their control nodes. This forces using the `Action::Change` pattern
to update nodes which allows the visitor framework to define what happens
when part of the AST changes during traversal.
