### PR TITLE
upgrade runt configuration

### DIFF
--- a/runt.toml
+++ b/runt.toml
@@ -1,3 +1,5 @@
+ver = "0.2.3"
+
 [[tests]]
 name = "Integration tests"
 paths = [ "tests/integration/*.futil" ]
@@ -7,3 +9,6 @@ cmd = "./target/debug/futil {} -l ./primitives/std.lib -b futil"
 name = "Automatic Par tests"
 paths = [ "tests/automatic-par/*.futil" ]
 cmd = "./target/debug/futil {} -l ./primitives/std.lib -b futil -p automatic-par"
+# This is just the default save directory. Use `expect_dir` when
+# using files from other test suites as input.
+expect_dir = "tests/automatic-par"


### PR DESCRIPTION
- Runt configuration tracks version of tool being used using `ver`. 
- Uses `expect_dir` to change the location of `.expect` files. This will allow us to use the same input files for multiple test suites.