### PR TITLE
Scriptify longer bash command in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,7 @@ clean:
 	./target/debug/futil $< -b verilog > $@
 
 %.vcd: %.v
-	mkdir -p $*_objs
-	cp sim/testbench.cpp $*_objs/testbench.cpp
-	verilator -cc --trace $< --exe testbench.cpp --top-module main --Mdir $*_objs
-	make -j -C $*_objs -f Vmain.mk Vmain
-	$*_objs/Vmain $@
-	rm -rf $*_objs
+	./bin/gen-vcd $<
 
 %.json: %.vcd
 	vcdump $< > $*.json

--- a/bin/gen-vcd
+++ b/bin/gen-vcd
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+### Simple helper script to run a verilog file using verilator and generate
+### VCD dumps. Used by our testing framework. Should probably *not* be used
+### in production designs.
+
 set -eux
 
 filename="$1"

--- a/bin/gen-vcd
+++ b/bin/gen-vcd
@@ -4,7 +4,10 @@
 ### VCD dumps. Used by our testing framework. Should probably *not* be used
 ### in production designs.
 
-set -eux
+# -e: fail on first error.
+# -u: fail on unset variables.
+# -f: disable filename globbing.
+set -euf
 
 filename="$1"
 stem="${filename%.*}"

--- a/bin/gen-vcd
+++ b/bin/gen-vcd
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eux
+
+filename="$1"
+stem="${filename%.*}"
+
+# Create a temporary folder to store objects generated from verilator.
+tmp="$(mktemp -d)"
+cp sim/testbench.cpp "$tmp"/
+
+# Generate required objects for verilator run.
+verilator -cc --trace "$filename" \
+  --exe testbench.cpp --top-module main --Mdir "$tmp"
+
+# Generate and execute verilator C harness.
+make -j -C "$tmp" -f Vmain.mk Vmain
+"$tmp"/Vmain "$stem".vcd
+
+# Clean up temporary folder.
+rm -rf "$tmp"


### PR DESCRIPTION
Move the longer bash sequences into a script so that we can check them
with `shellcheck`, emit good error messages, and avoid the various weird
behavior make has.