### PR TITLE
Add a real DNN to the Relay examples

### DIFF
--- a/relay-futil/README.md
+++ b/relay-futil/README.md
@@ -44,7 +44,7 @@ Try this to run a simple example:
 
     python3 example.py
 
-Pass the `-r` flag to this script to see the Relay code. Otherwise, we just print the FuTIL code.
+Pass the `-r` flag to this script to see the Relay code. Otherwise, we just print the FuTIL code. There is also an `-o` flag to try optimizing the Relay code a little bit.
 
 You can specify the name of an example as a command-line argument. The current options are `identity`, `add`, and `const`.
 

--- a/relay-futil/example.py
+++ b/relay-futil/example.py
@@ -1,5 +1,4 @@
 from tvm import relay
-from tvm import te
 from tvm.relay import parser
 import relay2futil
 import sys
@@ -47,33 +46,14 @@ def conv2d( weight=None, **kwargs):
     return relay.Function([data, weight], relay.nn.conv2d(data, weight, **kwargs))
 
 
-def broadcast_add(a_shape=(4, 1), b_shape=(4, 4)):
-    """The `broadcast_add` example from the "D2L book," which adds a
-    vector to every column of a matrix.
+def mlp_net():
+    """The MLP test from Relay.
     """
-    # https://tvm.d2l.ai/chapter_common_operators/broadcast_add.html
-    assert len(a_shape) == 2 and len(b_shape) == 2, \
-        "broadcast tensors should both be 2-dimension"
-    for i in range(len(a_shape)):
-        assert a_shape[i] == b_shape[i] \
-            or a_shape[i] == 1 or b_shape[i] == 1, \
-            "tensor shapes do not fit for broadcasting"
-    A = te.placeholder(a_shape, name='A')
-    B = te.placeholder(b_shape, name='B')
-    m = a_shape[0] if b_shape[0] == 1 else b_shape[0]
-    n = a_shape[1] if b_shape[1] == 1 else b_shape[1]
-
-    def f(x, y):
-        return A[0 if a_shape[0] == 1 else x,
-                 0 if a_shape[1] == 1 else y] + \
-               B[0 if b_shape[0] == 1 else x,
-                 0 if b_shape[1] == 1 else y]
-
-    C = te.compute((m, n), f, name='C')
-    return A, B, C
+    from tvm.relay.testing import mlp
+    return mlp.get_net(1)
 
 
-ALL_FUNCS = [identity, const, add, add_var, assign, conv2d]
+ALL_FUNCS = [identity, const, add, add_var, assign, conv2d, mlp_net]
 def simple_example():
     # See if the command line contains a function name.
     for option in ALL_FUNCS:

--- a/relay-futil/example.py
+++ b/relay-futil/example.py
@@ -67,15 +67,14 @@ def simple_example():
     if '-o' in sys.argv[1:]:
         # Try optimizing the Relay IR with a few built-in passes.
         seq = tvm.transform.Sequential([
+            relay.transform.SimplifyExpr(),
             relay.transform.SimplifyInference(),
-            relay.transform.FuseOps(0),
             relay.transform.ToANormalForm(),
-            relay.transform.InferType(),
         ])
 
         mod = tvm.IRModule.from_expr(func)
-        seq(mod)
-        func = mod['main']
+        mod_opt = seq(mod)
+        func = mod_opt['main']
 
     if '-r' in sys.argv[1:]:
         # Dump the Relay representation (for educational purposes).

--- a/relay-futil/example.py
+++ b/relay-futil/example.py
@@ -1,3 +1,4 @@
+import tvm
 from tvm import relay
 from tvm.relay import parser
 import relay2futil
@@ -62,6 +63,19 @@ def simple_example():
             break
     else:
         func = add()  # The default for no argument.
+
+    if '-o' in sys.argv[1:]:
+        # Try optimizing the Relay IR with a few built-in passes.
+        seq = tvm.transform.Sequential([
+            relay.transform.SimplifyInference(),
+            relay.transform.FuseOps(0),
+            relay.transform.ToANormalForm(),
+            relay.transform.InferType(),
+        ])
+
+        mod = tvm.IRModule.from_expr(func)
+        seq(mod)
+        func = mod['main']
 
     if '-r' in sys.argv[1:]:
         # Dump the Relay representation (for educational purposes).


### PR DESCRIPTION
This just steals the [MLP DNN](https://github.com/apache/incubator-tvm/blob/master/python/tvm/relay/testing/mlp.py) directly out of the [Relay tests](https://github.com/apache/incubator-tvm/tree/master/python/tvm/relay/testing). It results in pretty straightforward high-level IR:

```
fn (%data: Tensor[(1, 1, 28, 28), float32], %fc1_weight, %fc1_bias, %fc2_weight, %fc2_bias, %fc3_weight, %fc3_bias) {
  %0 = nn.batch_flatten(%data);
  %1 = nn.dense(%0, %fc1_weight, units=128);
  %2 = nn.bias_add(%1, %fc1_bias, axis=-1);
  %3 = nn.relu(%2);
  %4 = nn.dense(%3, %fc2_weight, units=64);
  %5 = nn.bias_add(%4, %fc2_bias, axis=-1);
  %6 = nn.relu(%5);
  %7 = nn.dense(%6, %fc3_weight, units=10);
  %8 = nn.bias_add(%7, %fc3_bias, axis=-1);
  nn.softmax(%8)
}
```

I also added an `-o` flag to the example script that runs a few Relay optimizations, including a conversion to A-normal form that may be useful for making sure we generate sequences.