### PR TITLE
[README] Fix -l command to avoid double path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,14 @@ at the same time.
 
 **Primitives Library**: FuTIL can use customizable libraries based on the
 backend. The libraries live under [primitives](primitives). You probably want
-to use `primitives/std/lib` with the `-l` flag.
+to use `primitives/std/lib` with the `-l` flag, which tells the compiler to look for ```primitives/primitives/std.lib```.
+You'll need to explicitly pass the flag if you're not in the root directory.
 
 ```bash
-cargo run -- examples/simple.futil -l primitives/std.lib
+$ cargo run -- examples/simples.futil       # In the root directory.
+
+$ cd futil/benchmarks
+$ cargo run -- ../benchmarks/examples/simple.futil -l ..
 ```
 
 **Debug mode**: The `-d` flag shows the FuTIL program after running a pass.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ to use `primitives/std/lib` with the `-l` flag, which tells the compiler to look
 You'll need to explicitly pass the flag if you're not in the root directory.
 
 ```bash
-$ cargo run -- examples/simples.futil       # In the root directory.
+$ cargo run -- examples/simples.futil    # In the root directory.
 
-$ cd futil/benchmarks
+$ cd benchmarks                          # Not in the root directory.
 $ cargo run -- ../benchmarks/examples/simple.futil -l ..
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ at the same time.
 
 **Primitives Library**: FuTIL can use customizable libraries based on the
 backend. The libraries live under [primitives](primitives). You probably want
-to use `primitives/std/lib` with the `-l` flag, which tells the compiler to look for ```primitives/primitives/std.lib```.
-You'll need to explicitly pass the flag if you're not in the root directory.
+to use `primitives/std.lib` with the `-l` flag, which tells the compiler to look for ```primitives/std.lib```.
+You'll need to explicitly pass the flag if you're not in the root directory. Assuming the import statement is ```import primitives/std.lib```:
 
 ```bash
-$ cargo run -- examples/simples.futil    # In the root directory.
+$ cargo run -- examples/simple.futil -l primitives      # WRONG: "Failed to read primitives/primitives/std.lib"
+$ cargo run -- examples/simples.futil                   # RIGHT
 
-$ cd benchmarks                          # Not in the root directory.
-$ cargo run -- ../examples/simple.futil -l ..
+$ cd benchmarks                                         # Outside root directory 
+$ cargo run -- ../examples/simple.futil -l ..           # RIGHT
 ```
 
 **Debug mode**: The `-d` flag shows the FuTIL program after running a pass.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You'll need to explicitly pass the flag if you're not in the root directory.
 $ cargo run -- examples/simples.futil    # In the root directory.
 
 $ cd benchmarks                          # Not in the root directory.
-$ cargo run -- ../benchmarks/examples/simple.futil -l ..
+$ cargo run -- ../examples/simple.futil -l ..
 ```
 
 **Debug mode**: The `-d` flag shows the FuTIL program after running a pass.


### PR DESCRIPTION
Let me know if you think this is unhelpful or too verbose. Also, maybe it would be helpful to actually have an ```examples/simple.futil```? Or, is there already one and I'm just not finding it?
Closes #209 