### PR TITLE
Add simple example that falls in line with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ The compiler can be run in two ways:
 1. `cargo run -- <options>`: Rebuild compiler and run the CLI.
 2. `./target/debug/futil <options>`: Run the compiler without rebuilding the CLI.
 
+Compile an example FuTIL program: [examples/simple.futil](examples/simple.futil)
+          
+          cargo run -- examples/simple.futil
+          
 Compile a FuTIL program to Verilog for Verilator simulation
 
-          cargo run -- <file> -b verilog --verilator -l primitives/std.lib
+          cargo run -- <file> -b verilog --verilator
 
 ### Compiler Development
 
@@ -64,6 +68,7 @@ to use `primitives/std.lib` with the `-l` flag, which tells the compiler to look
 You'll need to explicitly pass the flag if you're not in the root directory. Assuming the import statement is ```import primitives/std.lib```:
 
 ```bash
+$ cd futil                                              # Inside root directory.
 $ cargo run -- examples/simple.futil -l primitives      # WRONG: "Failed to read primitives/primitives/std.lib"
 $ cargo run -- examples/simple.futil                    # RIGHT
 

--- a/examples/simple.futil
+++ b/examples/simple.futil
@@ -1,0 +1,36 @@
+import "primitives/std.lib";
+
+// A simple example that takes the sum and product of two constants,
+// and places each in its own register.
+component main() -> () {
+  cells {
+    const0 = prim std_const(32, 4); // 32-bit width constant with value 4.
+    const1 = prim std_const(32, 5); // 32-bit width constant with value 5.
+
+    add    = prim std_add(32);      // 32-bit width adder.
+    mult   = prim std_mult(32);     // 32-bit width multiplier.
+
+    reg0   = prim std_reg(32);      // 32-bit width register.
+    reg1   = prim std_reg(32);      // 32-bit width register.
+  }
+
+  wires {
+    group add_constants {
+      add.left = const0.out;        // 4
+      add.right = const1.out;       // 5
+      reg0.in = add.out;            // 4 + 5
+    }
+    group multiply_constants {
+      mult.left = const0.out;       // 4
+      mult.right = const1.out;      // 5
+      reg1.in = mult.out;           // 4 * 5
+    }
+  }
+
+  control {
+    seq {                           // These are done sequentially.
+      add_constants;                // Put 9 in reg0.
+      multiply_constants;           // Put 20 in reg1.
+    }
+  }
+}


### PR DESCRIPTION
This adds an example to the main FuTIL repository, a part of #215 .
This code is a quick snapshot of FuTIL components, and is used mostly so that the code in the README at https://github.com/cucapra/futil#compiler-development works. 