### PR TITLE
[benchmarks] Use constant reference for vectors.

### DIFF
--- a/benchmarks/print_headers/printer.cpp
+++ b/benchmarks/print_headers/printer.cpp
@@ -1,25 +1,23 @@
 #include <vector>
 #include <cstdio>
 
-using std::vector;
-
 template <typename T>
-void print_vec(std::vector<T> &input) {
-	for (uint i = 0; i < input.size(); i++) {
-    printf("%.4f\n", input.at(i));
-	}
-}
-
-template<typename T>
-void print_vec_2d(std::vector<std::vector<T>> &input) {
-  for (uint i = 0; i < input.size(); i++) {
-    print_vec(input.at(i));
+void print_vec(const std::vector<T> &input) {
+  for (const auto &i : input) {
+    printf("%.4f\n", i);
   }
 }
 
 template<typename T>
-void print_vec_3d(std::vector<std::vector<std::vector<T>>> &input) {
-  for (uint i = 0; i < input.size(); i++) {
-    print_vec_2d(input.at(i));
+void print_vec_2d(const std::vector<std::vector<T>> &input) {
+  for (const auto &1d_vector : input) {
+    print_vec(1d_vector);
+  }
+}
+
+template<typename T>
+void print_vec_3d(const std::vector<std::vector<std::vector<T>>> &input) {
+  for (const auto &2d_vector : input) {
+    print_vec_2d(2d_vector);
   }
 }

--- a/benchmarks/print_headers/printer.cpp
+++ b/benchmarks/print_headers/printer.cpp
@@ -3,7 +3,7 @@
 
 template <typename T>
 void print_vec(const std::vector<T> &input) {
-  for (const auto &i : input) {
+  for (const auto i : input) {
     printf("%.4f\n", i);
   }
 }


### PR DESCRIPTION
Since values are not being modified, this should use constant references of the vectors. Similarly, we can use a ranged for loop to avoid index out-of-bounds errors.

I'm not quite sure of its use case here, but it would be more efficient to use a single std::vector as well, and use row-major ordering. Though, if this isn't a bottleneck of any sorts, then no need to change.