### PR TITLE
Fixes to avoid zero-time reset bug in simulation

### DIFF
--- a/calyx/src/backend/verilog.rs
+++ b/calyx/src/backend/verilog.rs
@@ -142,13 +142,23 @@ fn emit_component(comp: &ir::Component, memory_simulation: bool) -> v::Module {
         });
     }
 
-    // structure wire declarations
-    comp.cells
+    let wires = comp
+        .cells
         .iter()
         .flat_map(|cell| wire_decls(&cell.borrow()))
-        .for_each(|decl| {
-            module.add_decl(decl);
-        });
+        .collect_vec();
+    // structure wire declarations
+    wires.iter().for_each(|(name, width)| {
+        module.add_decl(v::Decl::new_logic(name, *width));
+    });
+    let mut initial = v::ParallelProcess::new_initial();
+    wires.iter().for_each(|(name, width)| {
+        initial.add_seq(v::Sequential::new_blk_assign(
+            v::Expr::new_ref(name),
+            v::Expr::new_ulit_dec(*width as u32, &0.to_string()),
+        ));
+    });
+    module.add_process(initial);
 
     // cell instances
     comp.cells
@@ -179,7 +189,7 @@ fn emit_component(comp: &ir::Component, memory_simulation: bool) -> v::Module {
     module
 }
 
-fn wire_decls(cell: &ir::Cell) -> Vec<v::Decl> {
+fn wire_decls(cell: &ir::Cell) -> Vec<(String, u64)> {
     cell.ports
         .iter()
         .filter_map(|port| match &port.borrow().parent {
@@ -188,16 +198,14 @@ fn wire_decls(cell: &ir::Cell) -> Vec<v::Decl> {
                 let parent = parent_ref.borrow();
                 match parent.prototype {
                     ir::CellType::Component { .. }
-                    | ir::CellType::Primitive { .. } => {
-                        Some(v::Decl::new_logic(
-                            format!(
-                                "{}_{}",
-                                parent.name.as_ref(),
-                                port.borrow().name.as_ref()
-                            ),
-                            port.borrow().width,
-                        ))
-                    }
+                    | ir::CellType::Primitive { .. } => Some((
+                        format!(
+                            "{}_{}",
+                            parent.name.as_ref(),
+                            port.borrow().name.as_ref()
+                        ),
+                        port.borrow().width,
+                    )),
                     _ => None,
                 }
             }

--- a/fud/sim/testbench.cpp
+++ b/fud/sim/testbench.cpp
@@ -30,13 +30,22 @@ int main(int argc, char **argv, char **env) {
     tfp->open(argv[1]);
   }
 
-  // initialize simulation inputs
+  // initialize simulation inputs and eval once to avoid zero-time reset bug (https://github.com/verilator/verilator/issues/2661)
+  top->go = 0;
+  top->eval();
   top->clk = 0;
-  top->go = 1;
+
   int done = 0;
+  int ignore_cycles = 5;
   printf("Starting simulation\n");
   while (done == 0 && i < n_cycles) {
     done = top->done;
+    // Do nothing for a few cycles to avoid zero-time reset bug
+    if (ignore_cycles == 0) {
+      top->go = 1;
+    } else {
+      ignore_cycles--;
+    }
     // dump variables into VCD file and toggle clock
     for (clk = 0; clk < 2; clk++) {
       if (trace) {
@@ -52,7 +61,7 @@ int main(int argc, char **argv, char **env) {
     i++;
   }
 
-  printf("Simulated %i cycles\n", i);
+  printf("Simulated %i cycles\n", i - ignore_cycles);
   top->final();
   if (trace) {
     tfp->close();


### PR DESCRIPTION
Fixes #284.

Lack of initial inputs causes a zero-time reset bug in simulation. See verilator/verilator#2661.
