### PR TITLE
Cull Frontend AST

### DIFF
--- a/calyx/src/errors.rs
+++ b/calyx/src/errors.rs
@@ -46,7 +46,7 @@ pub enum Error {
     /// The group has already been bound.
     DuplicateGroup(ir::Id),
     /// The port has already been defined.
-    DuplicatePort(ir::Id, ast::Portdef),
+    DuplicatePort(ir::Id, (ir::Id, u64)),
 
     /// No value provided for a primitive parameter.
     SignatureResolutionFailed(ir::Id, ir::Id),

--- a/calyx/src/frontend/ast.rs
+++ b/calyx/src/frontend/ast.rs
@@ -24,8 +24,11 @@ pub struct ComponentDef {
     /// List of instantiated sub-components
     pub cells: Vec<Cell>,
 
-    /// List of wires
-    pub connections: Vec<Connection>,
+    /// List of groups
+    pub groups: Vec<Group>,
+
+    /// List of continuous assignments
+    pub continuous_assignments: Vec<Wire>,
 
     /// Single control statement for this component.
     pub control: Control,
@@ -205,13 +208,6 @@ impl Cell {
             },
         }
     }
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
-pub enum Connection {
-    Group(Group),
-    Wire(Wire),
 }
 
 #[derive(Debug)]

--- a/calyx/src/frontend/ast.rs
+++ b/calyx/src/frontend/ast.rs
@@ -39,20 +39,10 @@ pub struct ComponentDef {
 #[derive(Clone, Debug)]
 pub struct Signature {
     /// List of input ports.
-    pub inputs: Vec<Portdef>,
+    pub inputs: Vec<(ir::Id, u64)>,
 
     /// List of output ports.
-    pub outputs: Vec<Portdef>,
-}
-
-/// The definition of an input/output port.
-#[derive(Clone, Debug)]
-pub struct Portdef {
-    /// The name of the port.
-    pub name: ir::Id,
-
-    /// The width of the port.
-    pub width: u64,
+    pub outputs: Vec<(ir::Id, u64)>,
 }
 
 /// Statement that refers to a port on a subcomponent.

--- a/calyx/src/frontend/ast.rs
+++ b/calyx/src/frontend/ast.rs
@@ -75,17 +75,6 @@ impl Port {
     }
 }
 
-/// Instantiates a subcomponent named `name` with
-/// paramters `params`.
-#[derive(Debug)]
-pub struct Compinst {
-    /// Name of the subcomponent to instantiate.
-    pub name: ir::Id,
-
-    /// List of parameters.
-    pub params: Vec<u64>,
-}
-
 // ===================================
 // AST for wire guard expressions
 // ===================================
@@ -146,56 +135,35 @@ pub struct Guard {
 // Data definitions for Structure
 // ===================================
 
-/// Data for the `new` structure statement.
-#[derive(Debug)]
-pub struct Decl {
-    /// Name of the variable being defined.
-    pub name: ir::Id,
-
-    /// Name of the component being instantiated.
-    pub component: ir::Id,
-}
-
-/// Data for the `new-std` structure statement.
-#[derive(Debug)]
-pub struct Prim {
-    /// Name of the variable being defined.
-    pub name: ir::Id,
-
-    /// Data for instantiating the library component.
-    pub instance: Compinst,
-}
-
 /// The Cell AST nodes.
 #[derive(Debug)]
 pub enum Cell {
     /// Node for instantiating user-defined components.
-    Decl { data: Decl },
+    Decl { name: ir::Id, component: ir::Id },
     /// Node for instantiating primitive components.
-    Prim { data: Prim },
+    Prim {
+        name: ir::Id,
+        prim: ir::Id,
+        params: Vec<u64>,
+    },
 }
 
 /// Methods for constructing the structure AST nodes.
 impl Cell {
-    /// Constructs `Structure::Decl` with `name` and `component`
-    /// as arguments.
-    pub fn decl(name: ir::Id, component: ir::Id) -> Cell {
-        Cell::Decl {
-            data: Decl { name, component },
-        }
-    }
-
     /// Constructs `Structure::Std` with `name` and `instance`
     /// as arguments.
     pub fn prim(var: ir::Id, prim_name: ir::Id, params: Vec<u64>) -> Cell {
         Cell::Prim {
-            data: Prim {
-                name: var,
-                instance: Compinst {
-                    name: prim_name,
-                    params,
-                },
-            },
+            name: var,
+            prim: prim_name,
+            params,
+        }
+    }
+
+    pub fn name(&self) -> &ir::Id {
+        match self {
+            Self::Decl { name, .. } => name,
+            Self::Prim { name, .. } => name,
         }
     }
 }

--- a/calyx/src/frontend/futil_syntax.pest
+++ b/calyx/src/frontend/futil_syntax.pest
@@ -33,7 +33,7 @@ bad_num = @{ ASCII_DIGIT ~ ('a'..'z' | 'A'..'Z' | '0'..'9' | "'")* }
 // ====== toplevel ======
 
 component = {
-      "component" ~ identifier ~ signature?
+      "component" ~ identifier ~ signature
       ~ "{"
       ~ cells
       ~ connections
@@ -58,7 +58,7 @@ imports = { import* }
 // ====== signature ======
 
 signature = {
-      "(" ~ io_ports? ~ ")" ~ signature_return?
+      "(" ~ io_ports? ~ ")" ~ signature_return
 }
 
 signature_return = {

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -375,15 +375,19 @@ impl FutilParser {
         ))
     }
 
-    fn connections(input: Node) -> ParseResult<Vec<ast::Connection>> {
-        input
-            .into_children()
-            .map(|node| match node.as_rule() {
-                Rule::wire => Ok(ast::Connection::Wire(Self::wire(node)?)),
-                Rule::group => Ok(ast::Connection::Group(Self::group(node)?)),
-                _ => unreachable!(),
-            })
-            .collect()
+    fn connections(
+        input: Node,
+    ) -> ParseResult<(Vec<ast::Wire>, Vec<ast::Group>)> {
+        let mut wires = Vec::new();
+        let mut groups = Vec::new();
+        for node in input.into_children() {
+            match node.as_rule() {
+                Rule::wire => wires.push(Self::wire(node)?),
+                Rule::group => groups.push(Self::group(node)?),
+                _ => unreachable!()
+            }
+        }
+        Ok((wires, groups))
     }
 
     fn enable(input: Node) -> ParseResult<ast::Control> {
@@ -487,26 +491,23 @@ impl FutilParser {
     fn component(input: Node) -> ParseResult<ast::ComponentDef> {
         Ok(match_nodes!(
         input.into_children();
-        [identifier(id), signature(sig), cells(cells), connections(connections), control(control)] =>
+        [
+            identifier(id),
+            signature(sig),
+            cells(cells),
+            connections(connections),
+            control(control)
+        ] => {
+            let (continuous_assignments, groups) = connections;
             ast::ComponentDef {
                 name: id,
                 signature: sig,
                 cells,
-                connections,
+                groups,
+                continuous_assignments,
                 control,
-            },
-            [identifier(id), cells(cells), connections(connections), control(control)] =>
-                ast::ComponentDef {
-                    name: id,
-                    signature: ast::Signature {
-                        inputs: vec![],
-                        outputs: vec![]
-                    },
-                    cells,
-                    connections,
-                    control,
-                },
-        ))
+            }
+        }))
     }
 
     fn imports(input: Node) -> ParseResult<Vec<String>> {

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -194,7 +194,7 @@ impl FutilParser {
         ))
     }
 
-    fn signature_return(input: Node) -> ParseResult<Vec<ast::Portdef>> {
+    fn signature_return(input: Node) -> ParseResult<Vec<(ir::Id, u64)>> {
         Ok(match_nodes!(
             input.into_children();
             [io_ports(p)] => p,
@@ -202,13 +202,13 @@ impl FutilParser {
         ))
     }
 
-    fn io_port(input: Node) -> ParseResult<ast::Portdef> {
+    fn io_port(input: Node) -> ParseResult<(ir::Id, u64)> {
         Ok(match_nodes![
             input.into_children();
-            [identifier(id), bitwidth(bw)] => ast::Portdef { name: id, width: bw }])
+            [identifier(id), bitwidth(bw)] => (id, bw)])
     }
 
-    fn io_ports(input: Node) -> ParseResult<Vec<ast::Portdef>> {
+    fn io_ports(input: Node) -> ParseResult<Vec<(ir::Id, u64)>> {
         Ok(match_nodes![
             input.into_children();
             [io_port(p)..] => p.collect()])
@@ -384,7 +384,7 @@ impl FutilParser {
             match node.as_rule() {
                 Rule::wire => wires.push(Self::wire(node)?),
                 Rule::group => groups.push(Self::group(node)?),
-                _ => unreachable!()
+                _ => unreachable!(),
             }
         }
         Ok((wires, groups))

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -233,8 +233,8 @@ impl FutilParser {
     fn component_cell(input: Node) -> ParseResult<ast::Cell> {
         Ok(match_nodes!(
             input.into_children();
-            [identifier(id), identifier(name)] =>
-                ast::Cell::decl(id, name)
+            [identifier(name), identifier(component)] =>
+                ast::Cell::Decl { name, component }
         ))
     }
 

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -40,7 +40,7 @@ fn extend_signature(sig: &mut ast::Signature) {
         .find(|(name, _)| name == "done")
         .is_none()
     {
-        sig.inputs.push(("done".into(), 1))
+        sig.outputs.push(("done".into(), 1))
     }
 }
 

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -121,24 +121,16 @@ fn build_component(
         .collect::<FutilResult<Vec<_>>>()?;
     ir_component.cells = cells;
 
-    // Build Groups and Assignments using Connections.
-    let (mut ast_groups, mut continuous) = (vec![], vec![]);
-    for conn in comp.connections.into_iter() {
-        match conn {
-            ast::Connection::Group(g) => ast_groups.push(g),
-            ast::Connection::Wire(w) => continuous.push(w),
-        }
-    }
-
     let mut builder =
         Builder::from(&mut ir_component, &sig_ctx.lib_sigs, false);
 
-    ast_groups
+    comp.groups
         .into_iter()
         .map(|g| build_group(g, &mut builder))
         .collect::<FutilResult<()>>()?;
 
-    let continuous_assignments = continuous
+    let continuous_assignments = comp
+        .continuous_assignments
         .into_iter()
         .map(|w| build_assignment(w, &mut builder))
         .collect::<FutilResult<Vec<_>>>()?;

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -26,25 +26,21 @@ struct SigCtx {
 fn extend_signature(sig: &mut ast::Signature) {
     // XXX(Sam): checking to see if the port exists is a hack.
     // The solution to the 'four big problems' will solve this.
-    if sig.inputs.iter().find(|pd| pd.name == "go").is_none() {
-        sig.inputs.push(ast::Portdef {
-            name: "go".into(),
-            width: 1,
-        });
+    if sig.inputs.iter().find(|(name, _)| name == "go").is_none() {
+        sig.inputs.push(("go".into(), 1))
     }
 
-    if sig.inputs.iter().find(|pd| pd.name == "clk").is_none() {
-        sig.inputs.push(ast::Portdef {
-            name: "clk".into(),
-            width: 1,
-        });
+    if sig.inputs.iter().find(|(name, _)| name == "clk").is_none() {
+        sig.inputs.push(("clk".into(), 1))
     }
 
-    if sig.outputs.iter().find(|pd| pd.name == "done").is_none() {
-        sig.outputs.push(ast::Portdef {
-            name: "done".into(),
-            width: 1,
-        });
+    if sig
+        .outputs
+        .iter()
+        .find(|(name, _)| name == "done")
+        .is_none()
+    {
+        sig.inputs.push(("done".into(), 1))
     }
 }
 
@@ -100,16 +96,8 @@ fn build_component(
     // Cell to represent the signature of this component
     let mut ir_component = Component::new(
         comp.name,
-        comp.signature
-            .inputs
-            .into_iter()
-            .map(|pd| (pd.name, pd.width))
-            .collect(),
-        comp.signature
-            .outputs
-            .into_iter()
-            .map(|pd| (pd.name, pd.width))
-            .collect(),
+        comp.signature.inputs,
+        comp.signature.outputs,
     );
 
     // For each ast::Cell, build an Cell that contains all the
@@ -161,16 +149,8 @@ fn build_cell(cell: ast::Cell, sig_ctx: &SigCtx) -> FutilResult<RRC<Cell>> {
                 CellType::Component {
                     name: component.clone(),
                 },
-                sig.inputs
-                    .iter()
-                    .cloned()
-                    .map(|pd| (pd.name, pd.width))
-                    .collect::<Vec<_>>(),
-                sig.outputs
-                    .iter()
-                    .cloned()
-                    .map(|pd| (pd.name, pd.width))
-                    .collect::<Vec<_>>(),
+                sig.inputs.clone(),
+                sig.outputs.clone(),
             ))
         }
         ast::Cell::Prim {

--- a/calyx/src/passes/well_formed.rs
+++ b/calyx/src/passes/well_formed.rs
@@ -54,20 +54,11 @@ impl Visitor for WellFormed {
         comp: &mut Component,
         _ctx: &LibrarySignatures,
     ) -> VisResult {
-        for group_ref in &comp.groups {
-            self.all_groups.insert(group_ref.borrow().name.clone());
-        }
         // Check if any of the cells use a reserved name.
         for cell_ref in &comp.cells {
             let cell = cell_ref.borrow();
             if self.reserved_names.contains(&cell.name.id) {
                 return Err(Error::ReservedName(cell.name.clone()));
-            }
-            if self.all_groups.contains(&cell.name) {
-                return Err(Error::AlreadyBound(
-                    cell.name.clone(),
-                    "group".to_string(),
-                ));
             }
         }
         Ok(Action::Continue)

--- a/tests/errors/duplicate-cells.expect
+++ b/tests/errors/duplicate-cells.expect
@@ -1,0 +1,6 @@
+---CODE---
+1
+---STDERR---
+Error: 
+6 |    r = prim std_reg(32);
+  |    ^ Name already bound by cell

--- a/tests/errors/duplicate-cells.futil
+++ b/tests/errors/duplicate-cells.futil
@@ -1,0 +1,10 @@
+import "primitives/std.lib";
+
+component main() -> () {
+  cells {
+    r = prim std_reg(32);
+    r = prim std_reg(32);
+  }
+  wires { }
+  control { }
+}

--- a/tests/errors/papercut-cell-and-group-conflict.expect
+++ b/tests/errors/papercut-cell-and-group-conflict.expect
@@ -2,5 +2,5 @@
 1
 ---STDERR---
 Error: 
-5 |    incr = prim std_add(32);
-  |    ^^^^ Name already bound by group
+9 |    group incr {
+  |          ^^^^ Name already bound by cell

--- a/tests/errors/papercut-cell-and-group-conflict.futil
+++ b/tests/errors/papercut-cell-and-group-conflict.futil
@@ -1,6 +1,6 @@
 import "primitives/std.lib";
 
-component main() {
+component main() -> () {
   cells {
     incr = prim std_add(32);
   }

--- a/tests/errors/papercut-cell-as-group.expect
+++ b/tests/errors/papercut-cell-as-group.expect
@@ -3,4 +3,4 @@
 ---STDERR---
 Error: 
 9 |    save;
-  |    ^^^^ Use of undefined group: save
+  |    ^^^^ Undefined group name: save

--- a/tests/passes/go-insertion.futil
+++ b/tests/passes/go-insertion.futil
@@ -2,7 +2,7 @@
 
 import "primitives/std.lib";
 
-component main() {
+component main() -> () {
   cells {
     add = prim std_add(32);
   }

--- a/tests/passes/minimize-regs/thread-local.futil
+++ b/tests/passes/minimize-regs/thread-local.futil
@@ -1,7 +1,7 @@
 // -p minimize-regs -p dead-cell-removal
 import "primitives/std.lib";
 
-component main {
+component main() -> () {
   cells {
     x = prim std_reg(32);
     y = prim std_reg(32);


### PR DESCRIPTION
Breaking change: Require components to have signature.

For example, these are now invalid:
```
component main { ... }
component main() { ... }
```

The only allowed form is:
```
component main() -> () { ... }
```

Relentlessly pursue consistency.
