### PR TITLE
Add attribute points

### DIFF
--- a/calyx/src/frontend/ast.rs
+++ b/calyx/src/frontend/ast.rs
@@ -3,7 +3,6 @@ use super::parser;
 use crate::errors::{Error, FutilResult, Span};
 use crate::ir;
 use atty::Stream;
-use linked_hash_map::LinkedHashMap;
 use std::io::stdin;
 use std::path::{Path, PathBuf};
 
@@ -117,7 +116,7 @@ pub struct ComponentDef {
     /// Single control statement for this component.
     pub control: Control,
     /// Attributes attached to this component
-    pub attributes: LinkedHashMap<String, u64>,
+    pub attributes: ir::Attributes,
 }
 
 /// Statement that refers to a port on a subcomponent.
@@ -232,7 +231,7 @@ pub struct Cell {
     /// Name of the prototype this cell was built from.
     pub prototype: CellType,
     /// Attributes attached to this cell definition
-    pub attributes: LinkedHashMap<String, u64>,
+    pub attributes: ir::Attributes,
 }
 
 /// Methods for constructing the structure AST nodes.
@@ -241,7 +240,7 @@ impl Cell {
     pub fn decl(
         name: ir::Id,
         comp: ir::Id,
-        attributes: LinkedHashMap<String, u64>,
+        attributes: ir::Attributes,
     ) -> Cell {
         Cell {
             name,
@@ -255,7 +254,7 @@ impl Cell {
         var: ir::Id,
         prim_name: ir::Id,
         params: Vec<u64>,
-        attributes: LinkedHashMap<String, u64>,
+        attributes: ir::Attributes,
     ) -> Cell {
         Cell {
             name: var,
@@ -272,7 +271,7 @@ impl Cell {
 pub struct Group {
     pub name: ir::Id,
     pub wires: Vec<Wire>,
-    pub attributes: LinkedHashMap<String, u64>,
+    pub attributes: ir::Attributes,
 }
 
 /// Data for the `->` structure statement.

--- a/calyx/src/frontend/ast.rs
+++ b/calyx/src/frontend/ast.rs
@@ -106,7 +106,7 @@ impl NamespaceDef {
 pub struct ComponentDef {
     /// Name of the component.
     pub name: ir::Id,
-    /// Defines input and output ports.
+    /// Defines input and output ports along with their attributes.
     pub signature: Vec<ir::PortDef>,
     /// List of instantiated sub-components
     pub cells: Vec<Cell>,
@@ -116,6 +116,8 @@ pub struct ComponentDef {
     pub continuous_assignments: Vec<Wire>,
     /// Single control statement for this component.
     pub control: Control,
+    /// Attributes attached to this component
+    pub attributes: LinkedHashMap<String, u64>,
 }
 
 /// Statement that refers to a port on a subcomponent.
@@ -229,34 +231,39 @@ pub struct Cell {
     pub name: ir::Id,
     /// Name of the prototype this cell was built from.
     pub prototype: CellType,
+    /// Attributes attached to this cell definition
+    pub attributes: LinkedHashMap<String, u64>,
 }
 
 /// Methods for constructing the structure AST nodes.
 impl Cell {
     /// Construct a Calyx cell instantiation.
-    pub fn decl(name: ir::Id, comp: ir::Id) -> Cell {
+    pub fn decl(
+        name: ir::Id,
+        comp: ir::Id,
+        attributes: LinkedHashMap<String, u64>,
+    ) -> Cell {
         Cell {
             name,
             prototype: CellType::Decl { name: comp },
+            attributes,
         }
     }
 
     /// Constructs a primitive cell instantiation.
-    pub fn prim(var: ir::Id, prim_name: ir::Id, params: Vec<u64>) -> Cell {
+    pub fn prim(
+        var: ir::Id,
+        prim_name: ir::Id,
+        params: Vec<u64>,
+        attributes: LinkedHashMap<String, u64>,
+    ) -> Cell {
         Cell {
             name: var,
             prototype: CellType::Prim {
                 name: prim_name,
                 params,
             },
-        }
-    }
-
-    /// Return the name of the cell.
-    pub fn name(&self) -> &ir::Id {
-        match &self.prototype {
-            CellType::Decl { name } => name,
-            CellType::Prim { name, .. } => name,
+            attributes,
         }
     }
 }

--- a/calyx/src/frontend/ast.rs
+++ b/calyx/src/frontend/ast.rs
@@ -208,36 +208,55 @@ pub struct Guard {
 // Data definitions for Structure
 // ===================================
 
-/// The Cell AST nodes.
+/// Prototype of the cell definition
 #[derive(Debug)]
-pub enum Cell {
-    /// Node for instantiating user-defined components.
-    Decl { name: ir::Id, component: ir::Id },
-    /// Node for instantiating primitive components.
+pub enum CellType {
+    /// An instantiated Calyx component.
+    Decl { name: ir::Id },
+    /// An instantiated primitive component.
     Prim {
+        /// Name of the primitive.
         name: ir::Id,
-        prim: ir::Id,
+        /// Parameter binding for primitives
         params: Vec<u64>,
     },
 }
 
+/// The Cell AST nodes.
+#[derive(Debug)]
+pub struct Cell {
+    /// Name of the cell.
+    pub name: ir::Id,
+    /// Name of the prototype this cell was built from.
+    pub prototype: CellType,
+}
+
 /// Methods for constructing the structure AST nodes.
 impl Cell {
-    /// Constructs `Structure::Std` with `name` and `instance`
-    /// as arguments.
+    /// Construct a Calyx cell instantiation.
+    pub fn decl(name: ir::Id, comp: ir::Id) -> Cell {
+        Cell {
+            name,
+            prototype: CellType::Decl { name: comp },
+        }
+    }
+
+    /// Constructs a primitive cell instantiation.
     pub fn prim(var: ir::Id, prim_name: ir::Id, params: Vec<u64>) -> Cell {
-        Cell::Prim {
+        Cell {
             name: var,
-            prim: prim_name,
-            params,
+            prototype: CellType::Prim {
+                name: prim_name,
+                params,
+            },
         }
     }
 
     /// Return the name of the cell.
     pub fn name(&self) -> &ir::Id {
-        match self {
-            Self::Decl { name, .. } => name,
-            Self::Prim { name, .. } => name,
+        match &self.prototype {
+            CellType::Decl { name } => name,
+            CellType::Prim { name, .. } => name,
         }
     }
 }

--- a/calyx/src/frontend/futil_syntax.pest
+++ b/calyx/src/frontend/futil_syntax.pest
@@ -1,6 +1,9 @@
 WHITESPACE = _{ " " | "\t" | NEWLINE }
 COMMENT = _{ ("//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE) | "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 
+// Semicolon
+semi = { ";" }
+
 ident_syms = _{ "_" | "-" | "'" }
 identifier = @{ ASCII_ALPHA+ ~ (ident_syms | ASCII_ALPHA | ASCII_DIGIT)* }
 
@@ -45,7 +48,7 @@ extern_or_component = {
 }
 
 component = {
-      "component" ~ identifier ~ signature
+      "component" ~ identifier ~ attributes? ~ signature
       ~ "{"
       ~ cells
       ~ connections
@@ -69,7 +72,7 @@ signature = {
 }
 
 io_port = {
-      identifier ~ ":" ~ (bitwidth | identifier)
+     at_attributes? ~ identifier ~ ":" ~ (bitwidth | identifier)
 }
 
 inputs = {
@@ -102,15 +105,15 @@ args = {
 
 
 primitive_cell = {
-      identifier ~ "=" ~ "prim" ~ identifier ~ args
+      at_attributes ~ identifier ~ "=" ~ "prim" ~ identifier ~ args
 }
 
 component_cell = {
-      identifier ~ "=" ~ identifier
+      at_attributes ~ identifier ~ "=" ~ identifier
 }
 
 cell = {
-      (primitive_cell | component_cell) ~ ";"
+      (primitive_cell | component_cell) ~ semi?
 }
 
 cells = {
@@ -179,12 +182,22 @@ wire = {
       LHS ~ "=" ~ (switch_stmt | expr) ~ ";"
 }
 
-key_value = {
+// =========== Attribute parsing ===============
+
+// <"static" = 1> style annotation
+attribute = {
       string_lit ~ "=" ~ bitwidth
 }
-
 attributes = {
-      "<" ~ (key_value ~ ("," ~ key_value)*) ~ ">"
+      "<" ~ (attribute ~ ("," ~ attribute)*) ~ ">"
+}
+
+// @static(1) style annotation
+at_attribute = {
+      "@" ~ identifier ~ "(" ~ bitwidth ~ ")"
+}
+at_attributes = {
+      at_attribute*
 }
 
 group = {

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -2,7 +2,6 @@
 use super::ast::{self, BitNum, NumType};
 use crate::errors::{self, FutilResult, Span};
 use crate::ir;
-use linked_hash_map::LinkedHashMap;
 use pest::prec_climber::{Assoc, Operator, PrecClimber};
 use pest_consume::{match_nodes, Error, Parser};
 use std::fs;
@@ -188,10 +187,10 @@ impl FutilParser {
         ))
     }
 
-    fn attributes(input: Node) -> ParseResult<LinkedHashMap<String, u64>> {
+    fn attributes(input: Node) -> ParseResult<ir::Attributes> {
         Ok(match_nodes!(
             input.into_children();
-            [attribute(kvs)..] => kvs.collect()
+            [attribute(kvs)..] => kvs.collect::<Vec<_>>().into()
         ))
     }
 
@@ -202,10 +201,10 @@ impl FutilParser {
         ))
     }
 
-    fn at_attributes(input: Node) -> ParseResult<LinkedHashMap<String, u64>> {
+    fn at_attributes(input: Node) -> ParseResult<ir::Attributes> {
         Ok(match_nodes!(
             input.into_children();
-            [at_attribute(kvs)..] => kvs.collect()
+            [at_attribute(kvs)..] => kvs.collect::<Vec<_>>().into()
         ))
     }
 
@@ -227,7 +226,7 @@ impl FutilParser {
 
     fn io_port(
         input: Node,
-    ) -> ParseResult<(ir::Id, ir::Width, LinkedHashMap<String, u64>)> {
+    ) -> ParseResult<(ir::Id, ir::Width, ir::Attributes)> {
         Ok(match_nodes!(
             input.into_children();
             [at_attributes(attrs), identifier(id), bitwidth(value)] =>
@@ -293,13 +292,13 @@ impl FutilParser {
                 name,
                 params: p,
                 signature: s,
-                attributes: LinkedHashMap::with_capacity(0),
+                attributes: ir::Attributes::default()
             },
             [identifier(name), signature(s)] => ir::Primitive {
                 name,
                 params: Vec::with_capacity(0),
                 signature: s,
-                attributes: LinkedHashMap::with_capacity(0),
+                attributes: ir::Attributes::default()
             }
         ))
     }
@@ -475,7 +474,7 @@ impl FutilParser {
             },
             [identifier(name), wire(wire)..] => ast::Group {
                 name,
-                attributes: LinkedHashMap::with_capacity(0),
+                attributes: ir::Attributes::default(),
                 wires: wire.collect()
             }
         ))
@@ -636,7 +635,7 @@ impl FutilParser {
                     groups,
                     continuous_assignments,
                     control,
-                    attributes: LinkedHashMap::with_capacity(0),
+                    attributes: ir::Attributes::default()
                 }
             },
             [

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -295,7 +295,7 @@ impl FutilParser {
         Ok(match_nodes!(
             input.into_children();
             [identifier(name), identifier(component)] =>
-                ast::Cell::Decl { name, component }
+                ast::Cell::decl(name, component)
         ))
     }
 

--- a/calyx/src/ir/attribute.rs
+++ b/calyx/src/ir/attribute.rs
@@ -1,0 +1,46 @@
+use linked_hash_map::LinkedHashMap;
+use std::ops::Index;
+
+/// Attributes associated with a specific IR structure.
+pub struct Attributes {
+    /// Mapping from the name of the attribute to its value.
+    attrs: LinkedHashMap<String, u64>,
+}
+
+impl Attributes {
+    /// Add a new attribute
+    pub fn insert<S>(&mut self, key: S, val: u64)
+    where
+        S: ToString + std::hash::Hash,
+    {
+        self.attrs.insert(key.to_string(), val);
+    }
+
+    /// Get the value associated with an attribute key
+    pub fn get<S>(&self, key: &S) -> Option<&u64>
+    where
+        S: ToString + std::cmp::Eq,
+    {
+        self.attrs.get(&key.to_string())
+    }
+
+    /// Check if an attribute key has been set
+    pub fn has<S>(&self, key: &S) -> bool
+    where
+        S: ToString + std::cmp::Eq,
+    {
+        self.attrs.contains_key(&key.to_string())
+    }
+}
+
+impl<S> Index<&S> for Attributes
+where
+    S: ToString + std::cmp::Eq + std::fmt::Display,
+{
+    type Output = u64;
+
+    fn index(&self, key: &S) -> &u64 {
+        self.get(&key)
+            .unwrap_or_else(|| panic!("No key `{}` in attribute map", key))
+    }
+}

--- a/calyx/src/ir/attribute.rs
+++ b/calyx/src/ir/attribute.rs
@@ -2,9 +2,27 @@ use linked_hash_map::LinkedHashMap;
 use std::ops::Index;
 
 /// Attributes associated with a specific IR structure.
+#[derive(Debug, Clone)]
 pub struct Attributes {
     /// Mapping from the name of the attribute to its value.
-    attrs: LinkedHashMap<String, u64>,
+    pub(super) attrs: LinkedHashMap<String, u64>,
+}
+
+impl Default for Attributes {
+    fn default() -> Self {
+        Attributes {
+            // Does not allocate any space.
+            attrs: LinkedHashMap::with_capacity(0),
+        }
+    }
+}
+
+impl From<Vec<(String, u64)>> for Attributes {
+    fn from(v: Vec<(String, u64)>) -> Self {
+        Attributes {
+            attrs: v.into_iter().collect(),
+        }
+    }
 }
 
 impl Attributes {
@@ -17,11 +35,11 @@ impl Attributes {
     }
 
     /// Get the value associated with an attribute key
-    pub fn get<S>(&self, key: &S) -> Option<&u64>
+    pub fn get<S>(&self, key: S) -> Option<&u64>
     where
-        S: ToString + std::cmp::Eq,
+        S: std::fmt::Display + AsRef<str>,
     {
-        self.attrs.get(&key.to_string())
+        self.attrs.get(&key.as_ref().to_string())
     }
 
     /// Check if an attribute key has been set
@@ -31,11 +49,15 @@ impl Attributes {
     {
         self.attrs.contains_key(&key.to_string())
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.attrs.is_empty()
+    }
 }
 
 impl<S> Index<&S> for Attributes
 where
-    S: ToString + std::cmp::Eq + std::fmt::Display,
+    S: AsRef<str> + std::fmt::Display,
 {
     type Output = u64;
 

--- a/calyx/src/ir/builder.rs
+++ b/calyx/src/ir/builder.rs
@@ -1,7 +1,6 @@
 //! IR Builder. Provides convience methods to build various parts of the internal
 //! representation.
 use crate::ir::{self, LibrarySignatures, RRC, WRC};
-use linked_hash_map::LinkedHashMap;
 use smallvec::smallvec;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -36,11 +35,7 @@ impl<'a> Builder<'a> {
     /// Construct a new group and add it to the Component.
     /// The group is guaranteed to start with `prefix`.
     /// Returns a reference to the group.
-    pub fn add_group<S>(
-        &mut self,
-        prefix: S,
-        attributes: LinkedHashMap<String, u64>,
-    ) -> RRC<ir::Group>
+    pub fn add_group<S>(&mut self, prefix: S) -> RRC<ir::Group>
     where
         S: Into<ir::Id> + ToString + Clone,
     {
@@ -49,7 +44,7 @@ impl<'a> Builder<'a> {
         // Check if there is a group with the same name.
         let group = Rc::new(RefCell::new(ir::Group {
             name,
-            attributes,
+            attributes: ir::Attributes::default(),
             holes: smallvec![],
             assignments: vec![],
         }));
@@ -61,7 +56,7 @@ impl<'a> Builder<'a> {
                 width: *width,
                 direction: ir::Direction::Inout,
                 parent: ir::PortParent::Group(WRC::from(&group)),
-                attributes: LinkedHashMap::with_capacity(0),
+                attributes: ir::Attributes::default(),
             }));
             group.borrow_mut().holes.push(hole);
         }
@@ -96,7 +91,7 @@ impl<'a> Builder<'a> {
                 "out".into(),
                 width,
                 ir::Direction::Output,
-                LinkedHashMap::with_capacity(0),
+                ir::Attributes::default(),
             )],
         );
 
@@ -271,7 +266,7 @@ impl<'a> Builder<'a> {
     pub(super) fn cell_from_signature(
         name: ir::Id,
         typ: ir::CellType,
-        ports: Vec<(ir::Id, u64, ir::Direction, LinkedHashMap<String, u64>)>,
+        ports: Vec<(ir::Id, u64, ir::Direction, ir::Attributes)>,
     ) -> RRC<ir::Cell> {
         let cell = Rc::new(RefCell::new(ir::Cell {
             name,
@@ -279,7 +274,7 @@ impl<'a> Builder<'a> {
             prototype: typ,
             // with_capacity(0) does not allocate space.
             // Same as HashMap::with_capacity
-            attributes: LinkedHashMap::with_capacity(0),
+            attributes: ir::Attributes::default(),
         }));
         ports
             .into_iter()

--- a/calyx/src/ir/component.rs
+++ b/calyx/src/ir/component.rs
@@ -2,6 +2,7 @@ use super::{
     Assignment, Builder, Cell, CellType, Control, Direction, Group, Id, RRC,
 };
 use crate::utils;
+use linked_hash_map::LinkedHashMap;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -25,6 +26,8 @@ pub struct Component {
     pub continuous_assignments: Vec<Assignment>,
     /// The control program for this component.
     pub control: RRC<Control>,
+    /// Attributes for this component
+    pub(super) attributes: LinkedHashMap<String, u64>,
 
     ///// Internal structures
     /// Namegenerator that contains the names currently defined in this
@@ -38,7 +41,10 @@ pub struct Component {
 ///   name.
 impl Component {
     /// Construct a new Component with the given `name` and signature fields.
-    pub fn new<S, N>(name: S, ports: Vec<(N, u64, Direction)>) -> Self
+    pub fn new<S, N>(
+        name: S,
+        ports: Vec<(N, u64, Direction, LinkedHashMap<String, u64>)>,
+    ) -> Self
     where
         S: AsRef<str>,
         N: AsRef<str>,
@@ -49,7 +55,9 @@ impl Component {
             ports
                 .into_iter()
                 // Reverse the port directions inside the component.
-                .map(|(name, w, d)| (name.as_ref().into(), w, d.reverse()))
+                .map(|(name, w, d, attrs)| {
+                    (name.as_ref().into(), w, d.reverse(), attrs)
+                })
                 .collect(),
         );
 
@@ -61,6 +69,7 @@ impl Component {
             continuous_assignments: vec![],
             control: Rc::new(RefCell::new(Control::empty())),
             namegen: utils::NameGenerator::default(),
+            attributes: LinkedHashMap::with_capacity(0),
         }
     }
 

--- a/calyx/src/ir/component.rs
+++ b/calyx/src/ir/component.rs
@@ -1,8 +1,8 @@
 use super::{
-    Assignment, Builder, Cell, CellType, Control, Direction, Group, Id, RRC,
+    Assignment, Attributes, Builder, Cell, CellType, Control, Direction, Group,
+    Id, RRC,
 };
 use crate::utils;
-use linked_hash_map::LinkedHashMap;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -27,7 +27,7 @@ pub struct Component {
     /// The control program for this component.
     pub control: RRC<Control>,
     /// Attributes for this component
-    pub(super) attributes: LinkedHashMap<String, u64>,
+    pub(super) attributes: Attributes,
 
     ///// Internal structures
     /// Namegenerator that contains the names currently defined in this
@@ -43,7 +43,7 @@ impl Component {
     /// Construct a new Component with the given `name` and signature fields.
     pub fn new<S, N>(
         name: S,
-        ports: Vec<(N, u64, Direction, LinkedHashMap<String, u64>)>,
+        ports: Vec<(N, u64, Direction, Attributes)>,
     ) -> Self
     where
         S: AsRef<str>,
@@ -69,7 +69,7 @@ impl Component {
             continuous_assignments: vec![],
             control: Rc::new(RefCell::new(Control::empty())),
             namegen: utils::NameGenerator::default(),
-            attributes: LinkedHashMap::with_capacity(0),
+            attributes: Attributes::default(),
         }
     }
 

--- a/calyx/src/ir/control.rs
+++ b/calyx/src/ir/control.rs
@@ -63,12 +63,6 @@ pub struct Invoke {
     pub outputs: PortMap,
 }
 
-impl From<RRC<Group>> for Enable {
-    fn from(group: RRC<Group>) -> Self {
-        Enable { group }
-    }
-}
-
 /// Data for the `empty` control statement.
 #[derive(Debug)]
 pub struct Empty {}

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -220,7 +220,8 @@ fn add_cell(cell: ast::Cell, sig_ctx: &SigCtx, builder: &mut Builder) {
 
 /// Build an IR group using the AST Group.
 fn add_group(group: ast::Group, builder: &mut Builder) -> FutilResult<()> {
-    let ir_group = builder.add_group(group.name, group.attributes);
+    let ir_group = builder.add_group(group.name);
+    ir_group.borrow_mut().attributes = group.attributes;
 
     // Add assignemnts to the group
     for wire in group.wires {

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -17,6 +17,7 @@ mod id;
 mod primitives;
 mod printer;
 mod structure;
+mod attribute;
 
 // Re-export types at the module level.
 pub use builder::Builder;
@@ -31,6 +32,7 @@ pub use printer::IRPrinter;
 pub use structure::{
     Assignment, Binding, Cell, CellType, Direction, Group, Port, PortParent,
 };
+pub use attribute::Attributes;
 
 /// Visitor to traverse a control program.
 pub mod traversal;

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -7,6 +7,7 @@
 //! 2. The IR attempts to represent similar concepts in a homogeneous manner.
 
 // Modules defining internal structures.
+mod attribute;
 mod builder;
 mod common;
 mod component;
@@ -17,9 +18,9 @@ mod id;
 mod primitives;
 mod printer;
 mod structure;
-mod attribute;
 
 // Re-export types at the module level.
+pub use attribute::Attributes;
 pub use builder::Builder;
 pub use common::{RRC, WRC};
 pub use component::Component;
@@ -32,7 +33,6 @@ pub use printer::IRPrinter;
 pub use structure::{
     Assignment, Binding, Cell, CellType, Direction, Group, Port, PortParent,
 };
-pub use attribute::Attributes;
 
 /// Visitor to traverse a control program.
 pub mod traversal;

--- a/calyx/src/ir/primitives.rs
+++ b/calyx/src/ir/primitives.rs
@@ -1,4 +1,4 @@
-use super::{Direction, Id};
+use super::{Attributes, Direction, Id};
 use crate::errors::{Error, FutilResult};
 use linked_hash_map::LinkedHashMap;
 use smallvec::SmallVec;
@@ -25,7 +25,7 @@ pub struct Primitive {
     /// The input/output signature for this primitive.
     pub signature: Vec<PortDef>,
     /// Key-value attributes for this primitive.
-    pub attributes: LinkedHashMap<String, u64>,
+    pub attributes: Attributes,
 }
 
 impl Primitive {
@@ -37,7 +37,7 @@ impl Primitive {
         parameters: &[u64],
     ) -> FutilResult<(
         SmallVec<[(Id, u64); 5]>,
-        Vec<(Id, u64, Direction, LinkedHashMap<String, u64>)>,
+        Vec<(Id, u64, Direction, Attributes)>,
     )> {
         let bindings = self
             .params
@@ -58,14 +58,6 @@ impl Primitive {
 
         Ok((bindings.into_iter().collect(), ports))
     }
-
-    /// Return the value associated with this attribute key.
-    pub fn get_attribute<S>(&self, attr: S) -> Option<&u64>
-    where
-        S: AsRef<str>,
-    {
-        self.attributes.get(attr.as_ref())
-    }
 }
 
 /// Definition of a port.
@@ -80,7 +72,7 @@ pub struct PortDef {
     /// or [`Direction::Output`].
     pub direction: Direction,
     /// Attributes attached to this port definition
-    pub attributes: LinkedHashMap<String, u64>,
+    pub attributes: Attributes,
 }
 
 impl From<(Id, u64, Direction)> for PortDef {
@@ -89,7 +81,7 @@ impl From<(Id, u64, Direction)> for PortDef {
             name: port.0,
             width: Width::Const { value: port.1 },
             direction: port.2,
-            attributes: LinkedHashMap::with_capacity(0),
+            attributes: Attributes::default(),
         }
     }
 }
@@ -110,7 +102,7 @@ impl PortDef {
     pub fn resolve(
         &self,
         binding: &LinkedHashMap<Id, u64>,
-    ) -> FutilResult<(Id, u64, LinkedHashMap<String, u64>)> {
+    ) -> FutilResult<(Id, u64, Attributes)> {
         match &self.width {
             Width::Const { value } => {
                 Ok((self.name.clone(), *value, self.attributes.clone()))

--- a/calyx/src/ir/printer.rs
+++ b/calyx/src/ir/printer.rs
@@ -2,7 +2,6 @@
 //! The printing operation clones inner nodes and doesn't perform any mutation
 //! to the Component.
 use crate::ir::{self, RRC};
-use linked_hash_map::LinkedHashMap;
 use std::io;
 use std::rc::Rc;
 
@@ -12,8 +11,9 @@ pub struct IRPrinter;
 impl IRPrinter {
     /// Format attributes of the form `@static(1)`.
     /// Returns the empty string if the `attrs` is empty.
-    fn format_at_attributes(attrs: &LinkedHashMap<String, u64>) -> String {
+    fn format_at_attributes(attrs: &ir::Attributes) -> String {
         attrs
+            .attrs
             .iter()
             .map(|(k, v)| format!("@{}({})", k, v))
             .collect::<Vec<_>>()
@@ -22,13 +22,14 @@ impl IRPrinter {
 
     /// Format attributes of the form `<"static"=1>`.
     /// Returns the empty string if the `attrs` is empty.
-    fn format_attributes(attrs: &LinkedHashMap<String, u64>) -> String {
+    fn format_attributes(attrs: &ir::Attributes) -> String {
         if attrs.is_empty() {
             "".to_string()
         } else {
             format!(
                 "<{}>",
                 attrs
+                    .attrs
                     .iter()
                     .map(|(k, v)| { format!("\"{}\"={}", k, v) })
                     .collect::<Vec<_>>()

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -44,6 +44,8 @@ pub struct Port {
     pub direction: Direction,
     /// Weak pointer to this port's parent
     pub parent: PortParent,
+    /// Attributes associated with this port.
+    pub attributes: LinkedHashMap<String, u64>,
 }
 
 impl Port {
@@ -127,6 +129,8 @@ pub struct Cell {
     pub ports: SmallVec<[RRC<Port>; 10]>,
     /// Underlying type for this cell
     pub prototype: CellType,
+    /// Attributes for this group.
+    pub(super) attributes: LinkedHashMap<String, u64>,
 }
 
 impl Cell {
@@ -183,6 +187,22 @@ impl Cell {
     /// (val, width) constant.
     pub(super) fn constant_name(val: u64, width: u64) -> Id {
         format!("_{}_{}", val, width).into()
+    }
+
+    /// Return the value associated with this attribute key.
+    pub fn get_attribute<S>(&self, attr: S) -> Option<&u64>
+    where
+        S: AsRef<str>,
+    {
+        self.attributes.get(attr.as_ref())
+    }
+
+    /// Add a new attribute to the group.
+    pub fn add_attribute<S>(&mut self, attr: S, value: u64)
+    where
+        S: Into<String>,
+    {
+        self.attributes.insert(attr.into(), value);
     }
 }
 

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -1,6 +1,5 @@
 //! Representation for structure (wires and cells) in a FuTIL program.
-use super::{Guard, Id, RRC, WRC};
-use linked_hash_map::LinkedHashMap;
+use super::{Attributes, Guard, Id, RRC, WRC};
 use smallvec::SmallVec;
 use std::rc::Rc;
 
@@ -45,7 +44,7 @@ pub struct Port {
     /// Weak pointer to this port's parent
     pub parent: PortParent,
     /// Attributes associated with this port.
-    pub attributes: LinkedHashMap<String, u64>,
+    pub attributes: Attributes,
 }
 
 impl Port {
@@ -130,7 +129,7 @@ pub struct Cell {
     /// Underlying type for this cell
     pub prototype: CellType,
     /// Attributes for this group.
-    pub(super) attributes: LinkedHashMap<String, u64>,
+    pub(super) attributes: Attributes,
 }
 
 impl Cell {
@@ -232,7 +231,7 @@ pub struct Group {
     pub holes: SmallVec<[RRC<Port>; 3]>,
 
     /// Attributes for this group.
-    pub(super) attributes: LinkedHashMap<String, u64>,
+    pub attributes: Attributes,
 }
 
 impl Group {
@@ -259,21 +258,5 @@ impl Group {
                 self.name.to_string()
             )
         })
-    }
-
-    /// Return the value associated with this attribute key.
-    pub fn get_attribute<S>(&self, attr: S) -> Option<&u64>
-    where
-        S: AsRef<str>,
-    {
-        self.attributes.get(attr.as_ref())
-    }
-
-    /// Add a new attribute to the group.
-    pub fn add_attribute<S>(&mut self, attr: S, value: u64)
-    where
-        S: Into<String>,
-    {
-        self.attributes.insert(attr.into(), value);
     }
 }

--- a/calyx/src/ir/traversal/visitor.rs
+++ b/calyx/src/ir/traversal/visitor.rs
@@ -275,7 +275,7 @@ impl Visitable for Control {
             Control::While(ctrl) => visitor
                 .start_while(ctrl, component, sigs)?
                 .and_then(|| {
-                    Control::Enable(ir::Enable::from(ctrl.cond.clone()))
+                    ir::Control::enable(ctrl.cond.clone())
                         .visit(visitor, component, sigs)
                 })?
                 .and_then(|| ctrl.body.visit(visitor, component, sigs))?

--- a/calyx/src/passes/compile_control.rs
+++ b/calyx/src/passes/compile_control.rs
@@ -6,7 +6,6 @@ use crate::ir::{
     LibrarySignatures,
 };
 use crate::{build_assignments, guard, structure};
-use linked_hash_map::LinkedHashMap;
 use std::convert::TryInto;
 use std::rc::Rc;
 
@@ -77,7 +76,7 @@ impl Visitor for CompileControl {
         let mut builder = ir::Builder::from(comp, ctx, false);
 
         // create a new group for if related structure
-        let if_group = builder.add_group("if", LinkedHashMap::new());
+        let if_group = builder.add_group("if");
 
         let cond_group = Rc::clone(&cif.cond);
         let cond = Rc::clone(&cif.port);
@@ -176,7 +175,7 @@ impl Visitor for CompileControl {
         let mut builder = ir::Builder::from(comp, ctx, false);
 
         // create group
-        let while_group = builder.add_group("while", LinkedHashMap::new());
+        let while_group = builder.add_group("while");
 
         // cond group
         let cond_group = Rc::clone(&wh.cond);
@@ -267,7 +266,7 @@ impl Visitor for CompileControl {
         let mut builder = ir::Builder::from(comp, ctx, false);
 
         // Create a new group for the seq related structure.
-        let seq_group = builder.add_group("seq", LinkedHashMap::new());
+        let seq_group = builder.add_group("seq");
         let fsm_size = get_bit_width_from(1 + s.stmts.len() as u64);
 
         // new structure
@@ -350,7 +349,7 @@ impl Visitor for CompileControl {
         let mut builder = ir::Builder::from(comp, ctx, false);
 
         // Name of the parent group.
-        let par_group = builder.add_group("par", LinkedHashMap::new());
+        let par_group = builder.add_group("par");
 
         let mut par_group_done: Vec<ir::Guard> =
             Vec::with_capacity(s.stmts.len());

--- a/calyx/src/passes/compile_empty.rs
+++ b/calyx/src/passes/compile_empty.rs
@@ -1,7 +1,6 @@
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{self, Component, Control, LibrarySignatures};
 use crate::{build_assignments, structure};
-use linked_hash_map::LinkedHashMap;
 use std::rc::Rc;
 
 #[derive(Default)]
@@ -42,12 +41,11 @@ impl Visitor for CompileEmpty {
             None => {
                 let mut builder = ir::Builder::from(comp, sigs, false);
                 // Create a group that always outputs done if it doesn't exist.
-                let mut attrs = LinkedHashMap::with_capacity(1);
-                attrs.insert("static".to_string(), 0);
 
                 // Add the new group
-                let empty_group = builder
-                    .add_group(CompileEmpty::EMPTY_GROUP.to_string(), attrs);
+                let empty_group =
+                    builder.add_group(CompileEmpty::EMPTY_GROUP.to_string());
+                empty_group.borrow_mut().attributes.insert("static", 0);
 
                 // Add this signal empty_group[done] = 1'd1;
                 structure!(builder;

--- a/calyx/src/passes/compile_invoke.rs
+++ b/calyx/src/passes/compile_invoke.rs
@@ -1,7 +1,6 @@
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{self, LibrarySignatures};
 use crate::{build_assignments, structure};
-use linked_hash_map::LinkedHashMap;
 
 /// Compiles [`ir::Invoke`](crate::ir::Invoke) statements into an [`ir::Enable`](crate::ir::Enable)
 /// that runs the invoked component.
@@ -27,8 +26,7 @@ impl Visitor for CompileInvoke {
     ) -> VisResult {
         let mut builder = ir::Builder::from(comp, ctx, false);
 
-        let invoke_group =
-            builder.add_group("invoke", LinkedHashMap::with_capacity(0));
+        let invoke_group = builder.add_group("invoke");
 
         // Generate state elements to make sure that component is only run once.
         // comp.go = 1'd1;

--- a/calyx/src/passes/infer_static_timing.rs
+++ b/calyx/src/passes/infer_static_timing.rs
@@ -319,7 +319,7 @@ impl Visitor for InferStaticTiming<'_> {
                 infer_latency(&group.borrow(), &self.prim_latency_data)
             {
                 let grp = group.borrow();
-                if let Some(curr_lat) = grp.get_attribute("static") {
+                if let Some(curr_lat) = grp.attributes.get("static") {
                     if *curr_lat != latency {
                         return Err(Error::ImpossibleLatencyAnnotation(
                             grp.name.to_string(),
@@ -335,7 +335,7 @@ impl Visitor for InferStaticTiming<'_> {
 
             match latency_result {
                 Some(res) => {
-                    group.borrow_mut().add_attribute("static".to_string(), res);
+                    group.borrow_mut().attributes.insert("static", res);
                 }
                 None => continue,
             }

--- a/calyx/src/passes/resource_sharing.rs
+++ b/calyx/src/passes/resource_sharing.rs
@@ -43,7 +43,8 @@ fn shareable_primitive_name(
         param_binding,
     } = &cell.borrow().prototype
     {
-        if let Some(&share) = sigs.get_primitive(&name).get_attribute("share") {
+        if let Some(&share) = sigs.get_primitive(&name).attributes.get("share")
+        {
             if share == 1 {
                 return Some((name.clone(), param_binding.clone()));
             }

--- a/calyx/src/passes/top_down_compile_control.rs
+++ b/calyx/src/passes/top_down_compile_control.rs
@@ -7,7 +7,6 @@ use crate::ir::{
 use crate::{build_assignments, guard, structure};
 use ir::IRPrinter;
 use itertools::Itertools;
-use linked_hash_map::LinkedHashMap;
 use petgraph::{algo::connected_components, graph::DiGraph};
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -317,7 +316,7 @@ fn realize_schedule(
     );
 
     // The compilation group
-    let group = builder.add_group("tdcc", LinkedHashMap::with_capacity(0));
+    let group = builder.add_group("tdcc");
 
     // Enable assignments
     group.borrow_mut().assignments.extend(
@@ -442,8 +441,7 @@ impl Visitor for TopDownCompileControl {
         let mut builder = ir::Builder::from(comp, sigs, false);
 
         // Compilation group
-        let par_group =
-            builder.add_group("par", LinkedHashMap::with_capacity(0));
+        let par_group = builder.add_group("par");
         structure!(builder;
             let signal_on = constant(1, 1);
             let signal_off = constant(0, 1);

--- a/tests/errors/mismatch-widths.expect
+++ b/tests/errors/mismatch-widths.expect
@@ -1,5 +1,5 @@
 ---CODE---
 101
 ---STDERR---
-thread 'main' panicked at 'Invalid assignment. `x.out' and `add.left' have different widths', calyx/src/ir/builder.rs:159:9
+thread 'main' panicked at 'Invalid assignment. `x.out' and `add.left' have different widths', calyx/src/ir/builder.rs:165:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/errors/mismatch-widths.expect
+++ b/tests/errors/mismatch-widths.expect
@@ -1,5 +1,5 @@
 ---CODE---
 101
 ---STDERR---
-thread 'main' panicked at 'Invalid assignment. `x.out' and `add.left' have different widths', calyx/src/ir/builder.rs:165:9
+thread 'main' panicked at 'Invalid assignment. `x.out' and `add.left' have different widths', calyx/src/ir/builder.rs:160:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/errors/parser/cell-missing-semi.expect
+++ b/tests/errors/parser/cell-missing-semi.expect
@@ -1,9 +1,10 @@
 ---CODE---
 1
 ---STDERR---
-Error: FuTIL Parser:  --> tests/errors/parser/cell-missing-semi.futil:3:5
+Error: FuTIL Parser:  --> 4:5
   |
-3 |     r = prim std_reg(32)␊
-  |     ^---
+4 |     h = prim std_reg(32)␊
+5 |     l = prim std_reg(32);␊
+  |     ^
   |
-  = expected cell
+  = Declaration is missing `;`

--- a/tests/errors/parser/cell-missing-semi.futil
+++ b/tests/errors/parser/cell-missing-semi.futil
@@ -1,6 +1,8 @@
 component main() -> () {
   cells {
-    r = prim std_reg(32)
+    r = prim std_reg(32);
+    h = prim std_reg(32)
+    l = prim std_reg(32);
   }
   wires { }
   control { }

--- a/tests/parsing/attributes.futil
+++ b/tests/parsing/attributes.futil
@@ -1,0 +1,14 @@
+import "primitives/core.futil";
+component main<"static"=1>(@stable(1) @go_port(1) in: 32) -> (@stable(0) out: 32) {
+  cells {
+    @precious(1) out = prim std_reg(32);
+    le = prim std_le(32);
+  }
+  wires {
+    group cond<"stable"=1> {
+      cond[done] = 1'd1;
+    }
+  }
+  control {
+  }
+}


### PR DESCRIPTION
Add attribute points for components, cell declarations, and port definitions:
```
import "primitives/core.futil";
component main<"static"=1>(@stable(1) @go_port(1) in: 32) -> (@stable(0) out: 32) {
  cells {
    @precious(1) out = prim std_reg(32);
    le = prim std_le(32);
  }
  wires {
    group cond<"stable"=1> {
      cond[done] = 1'd1;
    }
  }
  control {
  }
}
```

Fixes #311.