### PR TITLE
Infer static timing adds annotations to invoke

### DIFF
--- a/calyx/src/ir/traversal/mod.rs
+++ b/calyx/src/ir/traversal/mod.rs
@@ -4,4 +4,4 @@ mod visitor;
 
 pub use action::{Action, VisResult};
 pub use post_order::PostOrder;
-pub use visitor::{Loggable, Named, Visitable, Visitor};
+pub use visitor::{ConstructVisitor, Loggable, Named, Visitable, Visitor};

--- a/calyx/src/ir/traversal/post_order.rs
+++ b/calyx/src/ir/traversal/post_order.rs
@@ -40,24 +40,22 @@ impl PostOrder {
     /// # Panics
     /// Panics if there is no post-order traversal of the vectors possible.
     pub fn new(comps: Vec<ir::Component>) -> Self {
+        let mut graph: DiGraph<usize, ()> = DiGraph::new();
         // Reverse mapping from index to comps.
-        let rev_map: HashMap<ir::Id, u32> = comps
+        let rev_map: HashMap<ir::Id, NodeIndex> = comps
             .iter()
             .enumerate()
-            .map(|(idx, c)| (c.name.clone(), idx as u32))
+            .map(|(idx, c)| (c.name.clone(), graph.add_node(idx)))
             .collect::<HashMap<_, _>>();
 
         // Construct a graph.
-        let mut edges: Vec<(u32, u32)> = Vec::new();
-        let mut graph: DiGraph<usize, ()> = DiGraph::new();
         for comp in &comps {
             for cell in &comp.cells {
                 if let CellType::Component { name } = &cell.borrow().prototype {
-                    edges.push((rev_map[&name], rev_map[&comp.name]));
+                    graph.add_edge(rev_map[&name], rev_map[&comp.name], ());
                 }
             }
         }
-        graph.extend_with_edges(edges);
 
         // Build a topologically sorted ordering of the graph.
         let order = algo::toposort(&graph, None)

--- a/calyx/src/ir/traversal/visitor.rs
+++ b/calyx/src/ir/traversal/visitor.rs
@@ -48,6 +48,23 @@ where
     }
 }
 
+/// Trait defining method that can be used to construct a Visitor from an
+/// ir::Context.
+/// This is useful when a pass needs to construct information using the context
+/// *before* visiting the components.
+///
+/// For most passes that don't need to use, this is just going to use the
+/// default() method.
+pub trait ConstructVisitor {
+    fn from(_ctx: &ir::Context) -> Self;
+}
+
+impl<T: Default + Sized + Visitor> ConstructVisitor for T {
+    fn from(_ctx: &ir::Context) -> Self {
+        T::default()
+    }
+}
+
 /// The visiting interface for a [`ir::Control`](crate::ir::Control) program.
 /// Contains two kinds of functions:
 /// 1. start_<node>: Called when visiting <node> top-down.
@@ -128,9 +145,9 @@ pub trait Visitor {
     #[inline(always)]
     fn do_pass_default(context: &mut Context) -> FutilResult<Self>
     where
-        Self: Default + Sized,
+        Self: ConstructVisitor + Sized,
     {
-        let mut visitor = Self::default();
+        let mut visitor = Self::from(&*context);
         visitor.do_pass(context)?;
         Ok(visitor)
     }

--- a/calyx/src/passes/compile_invoke.rs
+++ b/calyx/src/passes/compile_invoke.rs
@@ -57,6 +57,11 @@ impl Visitor for CompileInvoke {
             .collect();
         invoke_group.borrow_mut().assignments = assigns;
 
+        // Copy "static" annotation if present
+        if let Some(time) = s.attributes.get("static") {
+            invoke_group.borrow_mut().attributes.insert("static", *time);
+        }
+
         Ok(Action::Change(ir::Control::enable(invoke_group)))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,9 @@ fn construct_pass_manager() -> FutilResult<PassManager> {
         pm,
         "pre-opt",
         [
+            InferStaticTiming,
             CompileInvoke,
             CollapseControl,
-            InferStaticTiming,
             ResourceSharing,
             MinimizeRegs
         ]

--- a/tests/passes/compile-invoke.expect
+++ b/tests/passes/compile-invoke.expect
@@ -16,7 +16,7 @@ component main(go: 1, clk: 1) -> (done: 1) {
     exp0 = exponent;
   }
   wires {
-    group invoke {
+    group invoke<"static"=0> {
       exp0.base = r.out;
       exp0.exp = const3.out;
       exp0.go = 1'd1;

--- a/tests/passes/compile-invoke.futil
+++ b/tests/passes/compile-invoke.futil
@@ -18,6 +18,6 @@ component main() -> () {
   wires {
   }
   control {
-    invoke exp0(base = r.out, exp = const3.out)();
+    @static(0) invoke exp0(base = r.out, exp = const3.out)();
   }
 }

--- a/tests/passes/infer-static/invoke.expect
+++ b/tests/passes/infer-static/invoke.expect
@@ -1,0 +1,49 @@
+import "primitives/core.futil";
+component main<"static"=3>(go: 1, clk: 1) -> (done: 1) {
+  cells {
+    r = prim std_reg(32);
+    exp0 = exponent;
+  }
+  wires {
+    group upd0<"static"=1> {
+      r.in = 32'd1;
+      r.write_en = 1'd1;
+      upd0[done] = r.done;
+    }
+  }
+
+  control {
+    @static(3) seq {
+      @static(1) upd0;
+      @static(2) invoke exp0(
+        base = r.out,
+        exp = r.out,
+      )();
+    }
+  }
+}
+component exponent<"static"=2>(base: 32, exp: 4, go: 1, clk: 1) -> (out: 32, done: 1) {
+  cells {
+    r1 = prim std_reg(32);
+    r2 = prim std_reg(32);
+  }
+  wires {
+    group upd2<"static"=1> {
+      r2.in = 32'd1;
+      r2.write_en = 1'd1;
+      upd2[done] = r2.done;
+    }
+    group upd1<"static"=1> {
+      r1.in = 32'd1;
+      r1.write_en = 1'd1;
+      upd1[done] = r1.done;
+    }
+  }
+
+  control {
+    @static(2) seq {
+      @static(1) upd1;
+      @static(1) upd2;
+    }
+  }
+}

--- a/tests/passes/infer-static/invoke.futil
+++ b/tests/passes/infer-static/invoke.futil
@@ -1,0 +1,52 @@
+// -p infer-static-timing
+import "primitives/core.futil";
+
+/**
+* Tests the infer-static-timing pass. `exponent` is intentionally placed
+* after main to test post-order iteration of components.
+*/
+component main() -> () {
+  cells {
+    r = prim std_reg(32);
+    exp0 = exponent;
+  }
+  wires {
+    group upd0 {
+      r.in = 32'd1;
+      r.write_en = 1'd1;
+      upd0[done] = r.done;
+    }
+  }
+  control {
+    seq {
+      upd0;
+      invoke exp0(base = r.out, exp = r.out)();
+    }
+  }
+}
+
+component exponent(base: 32, exp: 4) -> (out: 32) {
+  cells {
+    r1 = prim std_reg(32);
+    r2 = prim std_reg(32);
+  }
+  wires {
+    group upd2 {
+      r2.in = 32'd1;
+      r2.write_en = 1'd1;
+      upd2[done] = r2.done;
+    }
+    group upd1 {
+      r1.in = 32'd1;
+      r1.write_en = 1'd1;
+      upd1[done] = r1.done;
+    }
+  }
+  control {
+    seq {
+      upd1;
+      upd2;
+    }
+  }
+}
+


### PR DESCRIPTION
Changes `infer-static-timing` to use `require_postorder` and uses `"static"` annotations calculated on components to add static timing information on `invoke` statements.

`compile-invoke` is changed to copy the `static` attribute on the control node to the generated group.