### PR TITLE
Synthesis Papercut: Error read-only and write-only memories

### DIFF
--- a/calyx/src/analysis/graph.rs
+++ b/calyx/src/analysis/graph.rs
@@ -99,36 +99,52 @@ impl GraphAnalysis {
     /// Returns an iterator over all the reads from a port.
     /// Returns an empty iterator if this is an Input port.
     pub fn reads_from(&self, port: &ir::Port) -> PortIterator<'_> {
-        let idx = self.nodes[&port.canonical()];
-        match port.direction {
-            ir::Direction::Input => PortIterator::empty(),
-            ir::Direction::Output | ir::Direction::Inout => PortIterator {
-                port_iter: Box::new(
-                    self.graph.edges_directed(idx, Outgoing).map(move |edge| {
-                        let node_idx =
-                            self.graph.edge_endpoints(edge.id()).unwrap().1;
-                        Rc::clone(&self.graph[node_idx])
-                    }),
-                ),
-            },
+        if let Some(&idx) = self.nodes.get(&port.canonical()) {
+            match port.direction {
+                ir::Direction::Input => PortIterator::empty(),
+                ir::Direction::Output | ir::Direction::Inout => PortIterator {
+                    port_iter: Box::new(
+                        self.graph.edges_directed(idx, Outgoing).map(
+                            move |edge| {
+                                let node_idx = self
+                                    .graph
+                                    .edge_endpoints(edge.id())
+                                    .unwrap()
+                                    .1;
+                                Rc::clone(&self.graph[node_idx])
+                            },
+                        ),
+                    ),
+                },
+            }
+        } else {
+            PortIterator::empty()
         }
     }
 
     /// Returns an iterator over all the writes to this port.
     /// Returns an empty iterator if this is an Output port.
     pub fn writes_to(&self, port: &ir::Port) -> PortIterator<'_> {
-        let idx = self.nodes[&port.canonical()];
-        match port.direction {
-            ir::Direction::Input | ir::Direction::Inout => PortIterator {
-                port_iter: Box::new(
-                    self.graph.edges_directed(idx, Incoming).map(move |edge| {
-                        let node_idx =
-                            self.graph.edge_endpoints(edge.id()).unwrap().0;
-                        Rc::clone(&self.graph[node_idx])
-                    }),
-                ),
-            },
-            ir::Direction::Output => PortIterator::empty(),
+        if let Some(&idx) = self.nodes.get(&port.canonical()) {
+            match port.direction {
+                ir::Direction::Input | ir::Direction::Inout => PortIterator {
+                    port_iter: Box::new(
+                        self.graph.edges_directed(idx, Incoming).map(
+                            move |edge| {
+                                let node_idx = self
+                                    .graph
+                                    .edge_endpoints(edge.id())
+                                    .unwrap()
+                                    .0;
+                                Rc::clone(&self.graph[node_idx])
+                            },
+                        ),
+                    ),
+                },
+                ir::Direction::Output => PortIterator::empty(),
+            }
+        } else {
+            PortIterator::empty()
         }
     }
 

--- a/calyx/src/passes/mod.rs
+++ b/calyx/src/passes/mod.rs
@@ -17,6 +17,7 @@ mod papercut;
 mod resource_sharing;
 mod simplify_guards;
 mod static_timing;
+mod synthesis_papercut;
 mod top_down_compile_control;
 mod well_formed;
 
@@ -37,5 +38,6 @@ pub use papercut::Papercut;
 pub use resource_sharing::ResourceSharing;
 pub use simplify_guards::SimplifyGuards;
 pub use static_timing::StaticTiming;
+pub use synthesis_papercut::SynthesisPapercut;
 pub use top_down_compile_control::TopDownCompileControl;
 pub use well_formed::WellFormed;

--- a/calyx/src/passes/synthesis_papercut.rs
+++ b/calyx/src/passes/synthesis_papercut.rs
@@ -4,8 +4,9 @@ use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{self, LibrarySignatures};
 use std::collections::HashSet;
 
-/// Pass to check for common errors such as missing assignments to `done` holes
-/// of groups.
+/// Pass to check common synthesis issues.
+/// 1. If a memory is only read-from or written-to, synthesis tools will optimize it away. Add
+///    @external attribute to the cell definition to make it an interface memory.
 pub struct SynthesisPapercut {
     /// Names of memory primitives
     memories: HashSet<ir::Id>,
@@ -37,6 +38,7 @@ impl Visitor for SynthesisPapercut {
         comp: &mut ir::Component,
         _ctx: &LibrarySignatures,
     ) -> VisResult {
+        // Get all the memory cells.
         let memory_cells = comp
             .cells
             .iter()
@@ -54,6 +56,7 @@ impl Visitor for SynthesisPapercut {
             })
             .collect::<HashSet<_>>();
 
+        // Early return if there are no memory cells.
         if memory_cells.is_empty() {
             return Ok(Action::Stop);
         }

--- a/calyx/src/passes/synthesis_papercut.rs
+++ b/calyx/src/passes/synthesis_papercut.rs
@@ -1,0 +1,91 @@
+use crate::analysis::GraphAnalysis;
+use crate::errors::Error;
+use crate::ir::traversal::{Action, Named, VisResult, Visitor};
+use crate::ir::{self, LibrarySignatures};
+use std::collections::HashSet;
+
+/// Pass to check for common errors such as missing assignments to `done` holes
+/// of groups.
+pub struct SynthesisPapercut {
+    /// Names of memory primitives
+    memories: HashSet<ir::Id>,
+}
+
+impl Default for SynthesisPapercut {
+    fn default() -> Self {
+        let memories = ["std_mem_d1", "std_mem_d2", "std_mem_d3", "std_mem_d4"]
+            .iter()
+            .map(|&mem| mem.into())
+            .collect();
+        SynthesisPapercut { memories }
+    }
+}
+
+impl Named for SynthesisPapercut {
+    fn name() -> &'static str {
+        "synthesis-papercut"
+    }
+
+    fn description() -> &'static str {
+        "Detect common problems when targeting synthesis backends"
+    }
+}
+
+impl Visitor for SynthesisPapercut {
+    fn start(
+        &mut self,
+        comp: &mut ir::Component,
+        _ctx: &LibrarySignatures,
+    ) -> VisResult {
+        let memory_cells = comp
+            .cells
+            .iter()
+            .filter_map(|cell| {
+                let cell = &cell.borrow();
+                if self.memories.contains(&cell.name) {
+                    let has_external = cell.get_attribute("external");
+                    if has_external.is_none() {
+                        return Some(cell.name.clone());
+                    }
+                }
+                None
+            })
+            .collect::<HashSet<_>>();
+
+        if memory_cells.is_empty() {
+            return Ok(Action::Stop);
+        }
+
+        let has_mem_parent =
+            |p: &ir::Port| memory_cells.contains(&p.get_parent_name());
+        let analysis =
+            GraphAnalysis::from(&*comp).edge_induced_subgraph(|p1, p2| {
+                has_mem_parent(p1) || has_mem_parent(p2)
+            });
+
+        for mem in memory_cells {
+            let cell = comp.find_cell(&mem).unwrap();
+            let read_port = cell.borrow().get("read_data");
+            if analysis.reads_from(&*read_port.borrow()).next().is_none() {
+                return Err(Error::Papercut(
+                    format!(
+                        "Only reads performed on memory `{}'. Synthesis tools with remove this memory. Add @external(1) to cell to turn this into an interface memory",
+                        mem.to_string()
+                    ),
+                    mem,
+                ));
+            }
+            let write_port = cell.borrow().get("out");
+            if analysis.writes_to(&*write_port.borrow()).next().is_none() {
+                return Err(Error::Papercut(
+                    format!(
+                        "Only writes performed on memory `{}'. Synthesis tools with remove this memory. Add @external(1) to cell to turn this into an interface memory",
+                        mem.to_string()
+                    ),
+                    mem,
+                ));
+            }
+        }
+        Ok(Action::Stop)
+    }
+}

--- a/calyx/src/passes/synthesis_papercut.rs
+++ b/calyx/src/passes/synthesis_papercut.rs
@@ -4,6 +4,9 @@ use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{self, LibrarySignatures};
 use std::collections::HashSet;
 
+const READ_PORT: &str = "read_data";
+const WRITE_PORT: &str = "write_data";
+
 /// Pass to check common synthesis issues.
 /// 1. If a memory is only read-from or written-to, synthesis tools will optimize it away. Add
 ///    @external attribute to the cell definition to make it an interface memory.
@@ -70,7 +73,7 @@ impl Visitor for SynthesisPapercut {
 
         for mem in memory_cells {
             let cell = comp.find_cell(&mem).unwrap();
-            let read_port = cell.borrow().get("read_data");
+            let read_port = cell.borrow().get(READ_PORT);
             if analysis.reads_from(&*read_port.borrow()).next().is_none() {
                 return Err(Error::Papercut(
                     format!(
@@ -80,7 +83,7 @@ impl Visitor for SynthesisPapercut {
                     mem,
                 ));
             }
-            let write_port = cell.borrow().get("write_data");
+            let write_port = cell.borrow().get(WRITE_PORT);
             if analysis.writes_to(&*write_port.borrow()).next().is_none() {
                 return Err(Error::Papercut(
                     format!(

--- a/calyx/src/passes/synthesis_papercut.rs
+++ b/calyx/src/passes/synthesis_papercut.rs
@@ -69,13 +69,12 @@ impl Visitor for SynthesisPapercut {
             });
 
         for mem in memory_cells {
-            println!("{}", mem);
             let cell = comp.find_cell(&mem).unwrap();
             let read_port = cell.borrow().get("read_data");
             if analysis.reads_from(&*read_port.borrow()).next().is_none() {
                 return Err(Error::Papercut(
                     format!(
-                        "Only reads performed on memory `{}'. Synthesis tools with remove this memory. Add @external(1) to cell to turn this into an interface memory.",
+                        "Only reads performed on memory `{}'. Synthesis tools will remove this memory. Add @external(1) to cell to turn this into an interface memory.",
                         mem.to_string()
                     ),
                     mem,
@@ -85,7 +84,7 @@ impl Visitor for SynthesisPapercut {
             if analysis.writes_to(&*write_port.borrow()).next().is_none() {
                 return Err(Error::Papercut(
                     format!(
-                        "Only writes performed on memory `{}'. Synthesis tools with remove this memory. Add @external(1) to cell to turn this into an interface memory.",
+                        "Only writes performed on memory `{}'. Synthesis tools will remove this memory. Add @external(1) to cell to turn this into an interface memory.",
                         mem.to_string()
                     ),
                     mem,

--- a/runt.toml
+++ b/runt.toml
@@ -35,7 +35,7 @@ paths = [
   "tests/errors/parser/*.futil"
 ]
 cmd = """
-./target/debug/futil {} -p well-formed -p papercut
+./target/debug/futil {} -p well-formed -p papercut -p synthesis-papercut
 """
 
 ##### Correctness Tests #####

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use passes::{
     ClkInsertion, CollapseControl, CompileControl, CompileEmpty, CompileInvoke,
     ComponentInterface, DeadCellRemoval, Externalize, GoInsertion,
     InferStaticTiming, Inliner, MergeAssign, MinimizeRegs, Papercut,
-    ResourceSharing, SimplifyGuards, StaticTiming, TopDownCompileControl,
-    WellFormed,
+    ResourceSharing, SimplifyGuards, StaticTiming, SynthesisPapercut,
+    TopDownCompileControl, WellFormed,
 };
 use structopt::StructOpt;
 
@@ -40,6 +40,7 @@ fn construct_pass_manager() -> FutilResult<PassManager> {
     register_pass!(pm, SimplifyGuards);
     register_pass!(pm, MergeAssign);
     register_pass!(pm, TopDownCompileControl);
+    register_pass!(pm, SynthesisPapercut);
 
     register_alias!(pm, "validate", [WellFormed, Papercut]);
     register_alias!(

--- a/tests/errors/mem-only-reads.expect
+++ b/tests/errors/mem-only-reads.expect
@@ -1,0 +1,7 @@
+mem
+---CODE---
+1
+---STDERR---
+Error: 
+4 |    mem = std_mem_d1(32, 4, 4);
+  |    ^^^ [Papercut] Only writes performed on memory `mem'. Synthesis tools with remove this memory. Add @external(1) to cell to turn this into an interface memory

--- a/tests/errors/mem-only-reads.expect
+++ b/tests/errors/mem-only-reads.expect
@@ -1,7 +1,6 @@
-mem
 ---CODE---
 1
 ---STDERR---
 Error: 
 4 |    mem = std_mem_d1(32, 4, 4);
-  |    ^^^ [Papercut] Only writes performed on memory `mem'. Synthesis tools with remove this memory. Add @external(1) to cell to turn this into an interface memory
+  |    ^^^ [Papercut] Only writes performed on memory `mem'. Synthesis tools will remove this memory. Add @external(1) to cell to turn this into an interface memory.

--- a/tests/errors/mem-only-reads.futil
+++ b/tests/errors/mem-only-reads.futil
@@ -1,0 +1,18 @@
+import "primitives/core.futil";
+component main() -> () {
+  cells {
+    mem = std_mem_d1(32, 4, 4);
+    r = std_reg(32);
+  }
+  wires {
+    group do_read {
+      mem.addr0 = 4'd0;
+      r.in = mem.read_data;
+      r.write_en = 1'd1;
+      do_read[done] = r.done;
+    }
+  }
+  control {
+    do_read;
+  }
+}


### PR DESCRIPTION
New pass that generates and error when a memory is only used for reads or writes without @external(1). This pass should be enabled for the default synthesis alias.

Fixes #384.