### PR TITLE
[fud] Add space in InvalidNumericType error message.

### DIFF
--- a/fud/fud/stages/verilator/numeric_types.py
+++ b/fud/fud/stages/verilator/numeric_types.py
@@ -91,7 +91,7 @@ class Bitnum(NumericType):
 
         if len(self.bit_string_repr) > width:
             raise InvalidNumericType(
-                f"The value: {value} will overflow when trying to represent"
+                f"The value: {value} will overflow when trying to represent "
                 f"{len(self.bit_string_repr)} bits with width: {width}"
             )
 


### PR DESCRIPTION
cc: @crystalhu26 as well, since I can't add you as a reviewer. It was caught in the following error message:

```
[fud] ERROR: Invalid Numeric Type: The value: 5361170404089217488 will overflow when trying to represent63 bits with width: 13
```