### PR TITLE
[fud] Add empty defaults for FutilStage.

### DIFF
--- a/fud/fud/stages/futil.py
+++ b/fud/fud/stages/futil.py
@@ -11,6 +11,10 @@ class FutilStage(Stage):
         )
         self.setup()
 
+    @staticmethod
+    def defaults():
+        return {}
+
     def _define_steps(self, input_data):
         cmd = " ".join(
             [


### PR DESCRIPTION
Closes #746.

I changed this line:
https://github.com/cucapra/calyx/blob/b38639a86b50065eee9b3e86ea5593f0b33a0438/fud/icarus/icarus.py#L169

to:

```py
class FutilToIcarus(IcarusBaseStage):
```

and registered the stage. That worked; so it looks like `FutilStage` is missing defaults. I'm unsure if we want to give this mapping some values.

The other option is adding this `defaults` method directly to the class class `FutilToIcarus` above.