### PR TITLE
[Cider] Refactor debugger internals around breakpoints and watchpoints

### DIFF
--- a/cider/src/debugger/commands/command_parser.rs
+++ b/cider/src/debugger/commands/command_parser.rs
@@ -13,7 +13,10 @@ use pest_consume::{Error, Parser, match_nodes};
 type ParseResult<T> = std::result::Result<T, Error<Rule>>;
 type Node<'i> = pest_consume::Node<'i, Rule, ()>;
 
-use crate::{errors::CiderResult, serialization::PrintCode};
+use crate::{
+    debugger::commands::PointAction, errors::CiderResult,
+    serialization::PrintCode,
+};
 
 // include the grammar file so that Cargo knows to rebuild this file on grammar changes
 const _GRAMMAR: &str = include_str!("commands.pest");
@@ -204,37 +207,37 @@ impl CommandParser {
 
     fn delete(input: Node) -> ParseResult<Command> {
         Ok(match_nodes!(input.into_children();
-                [brk_id(br)..] => Command::Delete(br.collect())
-        ))
-    }
-
-    fn delete_watch(input: Node) -> ParseResult<Command> {
-        Ok(match_nodes!(input.into_children();
-                [brk_id(br)..] => Command::DeleteWatch(br.collect())
+                [brk_id(br)..] => Command::BreakAction(PointAction::Delete, br.collect())
         ))
     }
 
     fn enable(input: Node) -> ParseResult<Command> {
         Ok(match_nodes!(input.into_children();
-                [brk_id(br)..] => Command::Enable(br.collect())
+                [brk_id(br)..] => Command::BreakAction(PointAction::Enable, br.collect())
         ))
     }
 
     fn disable(input: Node) -> ParseResult<Command> {
         Ok(match_nodes!(input.into_children();
-                [brk_id(br)..] => Command::Disable(br.collect())
+                [brk_id(br)..] => Command::BreakAction(PointAction::Disable, br.collect())
+        ))
+    }
+
+    fn delete_watch(input: Node) -> ParseResult<Command> {
+        Ok(match_nodes!(input.into_children();
+                [brk_id(br)..] => Command::WatchAction(PointAction::Delete, br.collect())
         ))
     }
 
     fn enable_watch(input: Node) -> ParseResult<Command> {
         Ok(match_nodes!(input.into_children();
-                [brk_id(br)..] => Command::EnableWatch(br.collect())
+                [brk_id(br)..] => Command::WatchAction(PointAction::Enable, br.collect())
         ))
     }
 
     fn disable_watch(input: Node) -> ParseResult<Command> {
         Ok(match_nodes!(input.into_children();
-                [brk_id(br)..] => Command::DisableWatch(br.collect())
+                [brk_id(br)..] => Command::WatchAction(PointAction::Disable, br.collect())
         ))
     }
 

--- a/cider/src/debugger/commands/core.rs
+++ b/cider/src/debugger/commands/core.rs
@@ -137,6 +137,9 @@ impl From<BreakTarget> for ParsedBreakPointID {
 
 impl ParsedBreakPointID {
     /// Attempts to parse the breakpoint from user input into a concrete [BreakpointID].
+    /// Note that this function returns a `Vec` since a breakpoint given by group name
+    /// actually refers to all the enables of that group and hence multiple concrete
+    /// breakpoints
     pub fn parse_to_break_ids(
         &self,
         context: &Context,
@@ -452,6 +455,13 @@ impl ParsePath {
     }
 }
 
+/// The possible actions one could take on an extant break/watch point.
+pub enum PointAction {
+    Enable,
+    Disable,
+    Delete,
+}
+
 // Different types of printing commands
 pub enum PrintCommand {
     Normal,
@@ -482,18 +492,10 @@ pub enum Command {
     InfoBreak,
     /// List all watchpoints.
     InfoWatch,
-    /// Disable the given breakpoints.
-    Disable(Vec<ParsedBreakPointID>),
-    /// Enable the given breakpoints.
-    Enable(Vec<ParsedBreakPointID>),
-    /// Delete the given breakpoints.
-    Delete(Vec<ParsedBreakPointID>),
-    /// Enable the given watchpoints.
-    EnableWatch(Vec<ParsedBreakPointID>),
-    /// Disable the given watchpoints.
-    DisableWatch(Vec<ParsedBreakPointID>),
-    /// Delete the given watchpoints.
-    DeleteWatch(Vec<ParsedBreakPointID>),
+    /// Manipulate a given breakpoint
+    BreakAction(PointAction, Vec<ParsedBreakPointID>),
+    /// Manipulate a given watchpoint
+    WatchAction(PointAction, Vec<ParsedBreakPointID>),
     /// Advance the execution until the given group is no longer running.
     StepOver(BreakTarget, Option<NonZeroU32>),
     /// Create a watchpoint


### PR DESCRIPTION
Currently the commands for breakpoints and watchpoints are internally represented as three distinct commands each (not counting the commands to create them) this ends up creating a bunch of redundant code so I went ahead and consolidated them into a single command each with an enum that specifies the action to be taken.