### PR TITLE
Fix BRAM extraction

### DIFF
--- a/tools/report-parsing/synthrep/extract.py
+++ b/tools/report-parsing/synthrep/extract.py
@@ -29,6 +29,12 @@ def to_int(s):
     return int(s)
 
 
+def to_float(s):
+    if s == "-":
+        return 0.0
+    return float(s)
+
+
 def file_contains(regex, filename):
     strings = re.findall(regex, filename.open().read())
     return len(strings) == 0
@@ -79,7 +85,7 @@ def rpt_extract(file: Path):
         "summary": {
             "lut": to_int(lut),
             "dsp": to_int(dsp),
-            "brams": float(brams),
+            "brams": to_float(brams),
             "registers": to_int(reg),
             "carry8": to_int(carry8),
             "f7_muxes": to_int(f7_muxes),


### PR DESCRIPTION
This is just a tiny change to parse BRAM utilization as a `float` instead of an `int`, since Vivado can report fractional BRAM usage.