### PR TITLE
[doc] Actually fix mdbook

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,4 +5,3 @@ src = "docs"
 title = "Calyx Documentation"
 [output.html]
 mathjax-support = true
-[preprocessor.callouts] # https://github.com/ToolmanP/rs-mdbook-callouts


### PR DESCRIPTION
Last one didn't do it because the empty pre-processor callouts section was mad that the callout preprocessor wasn't installed. We don't use this feature currently so I just removed it.