### PR TITLE
[Profiler] Fix tiny bug for instrumentation pass order

### DIFF
--- a/calyx/opt/src/default_passes.rs
+++ b/calyx/opt/src/default_passes.rs
@@ -258,8 +258,8 @@ impl PassManager {
             [
                 "validate",
                 UniquefyEnables,
-                ProfilerInstrumentation,
                 DeadGroupRemoval,
+                ProfilerInstrumentation,
                 "pre-opt",
                 "compile",
                 "post-opt",

--- a/fud2/scripts/profiler.rhai
+++ b/fud2/scripts/profiler.rhai
@@ -82,7 +82,7 @@ fn py_to_profiled(e, input, output) {
     e.build_cmd(["$cell-json"], "component-cells", [calyx], []);
     e.build_cmd([instrumented_verilog], "calyx", [calyx], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p metadata-table-generation -p validate -p uniquefy-enables -p profiler-instrumentation -p dead-group-removal $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json -x uniquefy-enables:par-thread-json=enable-par-track.json -x uniquefy-enables:path-descriptor-json=path-descriptors.json");
+    e.arg("args", "-p metadata-table-generation -p validate -p uniquefy-enables -p dead-group-removal -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json -x uniquefy-enables:par-thread-json=enable-par-track.json -x uniquefy-enables:path-descriptor-json=path-descriptors.json");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()

--- a/fud2/tests/snapshots/tests__test@plan_calyx-py-profiler.snap
+++ b/fud2/tests/snapshots/tests__test@plan_calyx-py-profiler.snap
@@ -80,7 +80,7 @@ build $ctrl-pos-json $adl-metadata-json: parse-metadata-with-adl metadata-calyx.
 build $cell-json: component-cells calyx.futil
 build instrumented.sv: calyx calyx.futil
   backend = verilog
-  args = -p metadata-table-generation -p validate -p uniquefy-enables -p profiler-instrumentation -p dead-group-removal $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json -x uniquefy-enables:par-thread-json=enable-par-track.json -x uniquefy-enables:path-descriptor-json=path-descriptors.json
+  args = -p metadata-table-generation -p validate -p uniquefy-enables -p dead-group-removal -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json -x uniquefy-enables:par-thread-json=enable-par-track.json -x uniquefy-enables:path-descriptor-json=path-descriptors.json
 build verilator-out/Vtoplevel: verilator-compile-standalone-tb instrumented.sv | tb.sv
   out-dir = verilator-out
 build instrumented.exe: cp verilator-out/Vtoplevel


### PR DESCRIPTION
Fixing a tiny tiny bug!

In the profiler compile flow, we first have the `uniquefy-enables` pass that generates a unique copy of a group for every control invocation ("<group_name>UG", "<group_name>UG1", etc). That pass is followed by `profiler-instrumentation`, then `dead-group-removal` . So the original group gets removed, but a group probe for it is still produced (it just never gets high since it's not used anywhere in the wires section). Since the profiler's current implementation only reads active signals this was not really a problem, but we should fix it regardless!