### PR TITLE
[Profiler] Initial Rusted Petal implementation (probes)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -212,7 +212,7 @@ jobs:
     - name: Runt tests
       working-directory: /home/calyx
       run: |
-        runt -x 'cocotb|profiler' -d -o fail -j 1 --max-futures 5
+        runt -x 'cocotb|Petal' -d -o fail -j 1 --max-futures 5
 
     - name: Run Python Tests
       working-directory: /home/calyx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -77,6 +92,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -702,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -712,11 +736,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -724,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -870,12 +894,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac0790c83cfdab95709c5d0105fd888221e3af9049a7d7ec376ec901ab4e4dba"
 
 [[package]]
+name = "cranelift-bitset"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18391da761cf362a06def7a7cf11474d79e55801dd34c2e9ba105b33dc0aef88"
+
+[[package]]
 name = "cranelift-entity"
 version = "0.125.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "981b56af777f9a34ea6dcce93255125776d391410c2a68b75bed5941b714fa15"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.125.4",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8334c99a7e86060c24028732efd23bac84585770dcb752329c69f135d64f2fc1"
+dependencies = [
+ "cranelift-bitset 0.128.4",
 ]
 
 [[package]]
@@ -1246,7 +1285,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "log",
@@ -1372,13 +1411,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fst-reader"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982fa5eee1d7e5c1600b5082cc5ea2aafdaed1a06b82343306a390541e21683d"
+dependencies = [
+ "lz4_flex 0.13.1",
+ "miniz_oxide 0.9.1",
+ "num_enum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "fst-writer"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f14894e39cfd0728fa5313ee09898f0797ab526198fac5067959eaba959e858"
 dependencies = [
- "lz4_flex",
- "miniz_oxide",
+ "lz4_flex 0.11.5",
+ "miniz_oxide 0.8.9",
  "thiserror 2.0.18",
 ]
 
@@ -1401,7 +1452,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "manifest-dir-macros",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -1412,7 +1463,7 @@ dependencies = [
  "argh",
  "ariadne",
  "camino",
- "cranelift-entity",
+ "cranelift-entity 0.125.4",
  "env_logger",
  "figment",
  "insta",
@@ -1428,7 +1479,7 @@ dependencies = [
  "rustsat-minisat",
  "serde",
  "serde_json",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -1923,6 +1974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2077,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "manifest-dir-macros"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2102,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mimalloc"
@@ -2059,6 +2134,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "serde",
 ]
 
 [[package]]
@@ -2090,7 +2175,7 @@ version = "0.9.0"
 source = "git+https://github.com/pulp-platform/morty.git#8f578d8420c0279b7f47dba9c2d4821675ef2237"
 dependencies = [
  "anyhow",
- "clap 4.5.60",
+ "clap 4.6.1",
  "colored",
  "log",
  "petgraph",
@@ -2319,6 +2404,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2575,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "petal"
+version = "0.7.1"
+dependencies = [
+ "anyhow",
+ "baa",
+ "clap 4.6.1",
+ "cranelift-entity 0.128.4",
+ "rustc-hash",
+ "smallvec",
+ "wellen",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +2704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2903,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -3725,8 +3854,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3739,6 +3868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3747,9 +3885,30 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4169,6 +4328,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wellen"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed8ea1fe643ccfbd7bb1ae5ca53fa5a2815ea19d78655e3551585d52e4b3565"
+dependencies = [
+ "fst-reader",
+ "indexmap 2.13.0",
+ "leb128",
+ "lz4_flex 0.13.1",
+ "memmap2",
+ "miniz_oxide 0.9.1",
+ "num_enum",
+ "rayon",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4485,6 +4663,15 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "fst-reader"
-version = "0.16.6"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982fa5eee1d7e5c1600b5082cc5ea2aafdaed1a06b82343306a390541e21683d"
+checksum = "a63de2341e8d4d542158a1825c63ff1f2dc0870c1bb1100a8b3aef5aba8a9c1b"
 dependencies = [
  "lz4_flex 0.13.1",
  "miniz_oxide 0.9.1",
@@ -4329,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "wellen"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed8ea1fe643ccfbd7bb1ae5ca53fa5a2815ea19d78655e3551585d52e4b3565"
+checksum = "30b16cbe9ccd81bfc2f62cf8bf721956f715c56918d2bae16af749740a639db6"
 dependencies = [
  "fst-reader",
  "indexmap 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,11 @@ members = [
     "tools/yxi",
     "tools/calyx-writer",
     "tools/data_gen",
+    "tools/petal",
     "calyx-lsp",
 
     # Playground crate
-    "web/rust",
+    "web/rust"
 ]
 exclude = ["site"]
 

--- a/runt.toml
+++ b/runt.toml
@@ -718,3 +718,18 @@ cmd = """
  fud2 axi-wrapped.futil --from calyx --to verilog-noverify -o axi-wrapped.v 2> /dev/null && \
  fud2 axi-wrapped.v --from verilog-noverify --to cocotb-axi --set sim.data=${dirname}/../vectorized-add.data 2> /dev/null
  """
+
+### Profiling test
+[[tests]]
+name = "Petal rust implementation"
+paths = ["tools/petal/test/*.futil"]
+cmd = """
+dirname=$(dirname {}) && \
+basename=$(basename {} .futil) && \
+svg=${petal_test_dir}/${basename}.svg && \
+petal_test_dir=${dirname}/${basename} && \
+fud2 {} -o ${svg} --through profiler -s sim.data={}.data --dir ${petal_test_dir} 2> /dev/null
+
+target/debug/petal ${petal_test_dir}/instrumented.vcd && \
+rm -rf ${petal_test_dir}
+"""

--- a/tests/passes/profiler_instrumentation/structural-enable-cond.expect
+++ b/tests/passes/profiler_instrumentation/structural-enable-cond.expect
@@ -1,0 +1,39 @@
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    @external a = comb_mem_d1(32, 1, 1);
+    lt = std_lt(32);
+    @control @generated @protected wr_a___main_group_probe = std_wire(1);
+    @control @generated @protected a___wr_a___main_primitive_probe = std_wire(1);
+    @control @generated @protected wr_b___main_group_probe = std_wire(1);
+    @control @generated @protected wr_a___wr_b___main_se_probe = std_wire(1);
+    @control @generated @protected cond___main_group_probe = std_wire(1);
+    @control @generated @protected lt___cond___main_primitive_probe = std_wire(1);
+  }
+  wires {
+    group wr_a {
+      a.addr0 = 1'd0;
+      a.write_en = 1'd1;
+      a.write_data = 32'd1;
+      wr_a[done] = a.done;
+      wr_a___main_group_probe.in = 1'd1;
+      a___wr_a___main_primitive_probe.in = 1'd1;
+    }
+    group wr_b {
+      wr_a[go] = lt.out ? 1'd1;
+      wr_b[done] = wr_a[done];
+      wr_b___main_group_probe.in = 1'd1;
+      wr_a___wr_b___main_se_probe.in = lt.out ? 1'd1;
+    }
+    comb group cond {
+      lt.left = 32'd5;
+      lt.right = 32'd9;
+      cond___main_group_probe.in = 1'd1;
+      lt___cond___main_primitive_probe.in = 1'd1;
+    }
+  }
+  control {
+    wr_b;
+  }
+}

--- a/tests/passes/profiler_instrumentation/structural-enable-cond.expect
+++ b/tests/passes/profiler_instrumentation/structural-enable-cond.expect
@@ -8,8 +8,6 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     @control @generated @protected a___wr_a___main_primitive_probe = std_wire(1);
     @control @generated @protected wr_b___main_group_probe = std_wire(1);
     @control @generated @protected wr_a___wr_b___main_se_probe = std_wire(1);
-    @control @generated @protected cond___main_group_probe = std_wire(1);
-    @control @generated @protected lt___cond___main_primitive_probe = std_wire(1);
   }
   wires {
     group wr_a {
@@ -21,16 +19,10 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       a___wr_a___main_primitive_probe.in = 1'd1;
     }
     group wr_b {
-      wr_a[go] = lt.out ? 1'd1;
+      wr_a[go] = 1'd1;
       wr_b[done] = wr_a[done];
       wr_b___main_group_probe.in = 1'd1;
-      wr_a___wr_b___main_se_probe.in = lt.out ? 1'd1;
-    }
-    comb group cond {
-      lt.left = 32'd5;
-      lt.right = 32'd9;
-      cond___main_group_probe.in = 1'd1;
-      lt___cond___main_primitive_probe.in = 1'd1;
+      wr_a___wr_b___main_se_probe.in = 1'd1;
     }
   }
   control {

--- a/tests/passes/profiler_instrumentation/structural-enable-cond.futil
+++ b/tests/passes/profiler_instrumentation/structural-enable-cond.futil
@@ -1,0 +1,34 @@
+// -p profiler-instrumentation
+
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+
+component main() -> () {
+  cells {
+    @external(1) a = comb_mem_d1(32, 1, 1);
+    lt = std_lt(32);
+  }
+
+  wires {
+    comb group cond {
+      lt.left = 32'd5;
+      lt.right = 32'd9;
+    }
+
+    group wr_a {
+      a.addr0 = 1'b0;
+      a.write_en = 1'b1;
+      a.write_data = 32'd1;
+      wr_a[done] = a.done;
+    }
+
+    group wr_b {
+    wr_a[go] = lt.out ? 1'b1;
+    wr_b[done] = wr_a[done];
+    }
+  }
+
+  control {
+      wr_b;
+  }
+}

--- a/tests/passes/profiler_instrumentation/structural-enable-cond.futil
+++ b/tests/passes/profiler_instrumentation/structural-enable-cond.futil
@@ -10,12 +10,7 @@ component main() -> () {
   }
 
   wires {
-    comb group cond {
-      lt.left = 32'd5;
-      lt.right = 32'd9;
-    }
-
-    group wr_a {
+   group wr_a {
       a.addr0 = 1'b0;
       a.write_en = 1'b1;
       a.write_data = 32'd1;
@@ -23,7 +18,7 @@ component main() -> () {
     }
 
     group wr_b {
-    wr_a[go] = lt.out ? 1'b1;
+    wr_a[go] = 1'b1;
     wr_b[done] = wr_a[done];
     }
   }

--- a/tests/passes/profiler_instrumentation/structural-enable-cond.futil.data
+++ b/tests/passes/profiler_instrumentation/structural-enable-cond.futil.data
@@ -1,0 +1,12 @@
+{
+  "a": {
+    "data": [
+      0
+    ],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": true,
+      "width": 32
+    }
+  }
+}

--- a/tools/petal/Cargo.toml
+++ b/tools/petal/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.90.0"
 [dependencies]
 anyhow.workspace = true
 clap = { version = "4.6", features = ["derive"] }
-wellen = "0.24.2"
+wellen = "0.25.2"
 baa.workspace = true
 rustc-hash = "2.1.2"
 cranelift-entity = "0.128.4"

--- a/tools/petal/Cargo.toml
+++ b/tools/petal/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "petal"
+authors.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+repository.workspace = true
+readme.workspace = true
+description.workspace = true
+categories.workspace = true
+homepage.workspace = true
+edition.workspace = true
+version.workspace = true
+rust-version = "1.90.0"
+
+[dependencies]
+anyhow.workspace = true
+clap = { version = "4.6", features = ["derive"] }
+wellen = "0.24.2"
+baa.workspace = true
+rustc-hash = "2.1.2"
+cranelift-entity = "0.128.4"
+smallvec.workspace = true

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -22,10 +22,10 @@ struct Cell {
     scope: ScopeRef,
     /// Is the cell a primitive?
     is_primitive: bool,
-    /// If the cell is of the main component, contains a ref to the probe (main.go).
-    probe: Option<SignalRef>,
-    /// If the cell is of the main component, contains the bitvector index to the probe (main.go).
-    probe_idx: Option<u32>,
+    /// If the cell is of the main component, contains a ref to main.go and main.done.
+    probes: Option<(SignalRef, SignalRef)>,
+    /// If the cell is of the main component, contains the bitvector index for main.go and main.done.
+    probe_idxs: Option<(u32, u32)>,
     /// Non-empty if the cell is from a user-defined component.
     /// FIXME: might be worth pulling the primitive's original name as well?
     component: String,
@@ -82,6 +82,13 @@ struct Invoke {
     probe_idx: u32,
 }
 
+// TODO: Accommodate structural enables
+// #[derive(Debug, Clone)]
+// enum InvokeTarget {
+//     Cell(CellId),
+//     Group(GroupId),
+// }
+
 #[derive(Clone, Debug)]
 /// Represents the static call tree (all possible calls).
 pub struct Design {
@@ -128,7 +135,9 @@ impl Design {
         values: &BitVecValue,
     ) -> Result<Vec<Stack>> {
         let main = &self.cells[self.main];
-        let main_active = values.is_bit_set(main.probe_idx.unwrap());
+        let (main_go, main_done) = main.probe_idxs.unwrap();
+        let main_active =
+            values.is_bit_set(main_go) & !values.is_bit_set(main_done);
         let mut stacks = vec![];
         if main_active {
             stacks = self.compute_cell(values, self.main, vec![]);
@@ -188,9 +197,10 @@ impl Design {
         mut prefix: Stack,
     ) -> Vec<Stack> {
         let cell = &self.cells[cell_id];
-        if let Some(idx) = cell.probe_idx {
+        if let Some((main_go_idx, main_done_idx)) = cell.probe_idxs {
             // the main component cell is the only one to have a probe_idx.
-            if value.is_bit_set(idx) {
+            if value.is_bit_set(main_go_idx) && !value.is_bit_set(main_done_idx)
+            {
                 prefix.push(cell.display_name());
             } else {
                 return vec![prefix];
@@ -268,8 +278,11 @@ impl Design {
         );
 
         for (_, cell) in self.cells.iter_mut() {
-            if let Some(p) = cell.probe {
-                cell.probe_idx = Some(to_index[&p]);
+            if let Some((main_go_probe, main_done_probe)) = cell.probes {
+                cell.probe_idxs = Some((
+                    to_index[&main_go_probe],
+                    to_index[&main_done_probe],
+                ));
             }
         }
 
@@ -286,8 +299,9 @@ impl Design {
     fn probe_signals(&self) -> Vec<SignalRef> {
         let mut signals = vec![];
         for cell in self.cells.values() {
-            if let Some(p) = cell.probe {
-                signals.push(p);
+            if let Some((main_go_probe, main_done_probe)) = cell.probes {
+                signals.push(main_go_probe);
+                signals.push(main_done_probe);
             }
         }
 
@@ -312,15 +326,16 @@ impl Design {
             .lookup_scope(&[&"toplevel", &"main"])
             .with_context(|| format!("Failed to find main scope"))?;
         let main_go = get_var(h, &h[main_scope], "go")?;
+        let main_done = get_var(h, &h[main_scope], "done")?;
         let mut main_cell = Cell {
             name: "main".to_string(),
             groups: smallvec![],
-            probe: Some(h[main_go].signal_ref()),
+            probes: Some((h[main_go].signal_ref(), h[main_done].signal_ref())),
             scope: main_scope,
             is_primitive: false,
             instances: smallvec![],
             component: String::new(),
-            probe_idx: None,
+            probe_idxs: None,
         };
         self.scan_probes(h, main_scope, &mut main_cell)?;
         self.main = self.cells.push(main_cell);
@@ -407,8 +422,8 @@ impl Design {
                                 is_primitive,
                                 instances: smallvec![],
                                 component: String::new(),
-                                probe: None,
-                                probe_idx: None,
+                                probes: None,
+                                probe_idxs: None,
                             };
                             self.scan_probes(h, scope, &mut cell_instance)?;
                             let cell_id = self.cells.push(cell_instance);

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -19,7 +19,7 @@ struct Cell {
     /// NOTE: Primitive cells should have an empty vec here.
     groups: SmallVec<[GroupId; 6]>,
     /// The scope of the cell in the RTL trace.
-    scope: ScopeRef,
+    _scope: ScopeRef,
     /// Is the cell a primitive?
     is_primitive: bool,
     /// If the cell is of the main component, contains a ref to main.go and main.done.
@@ -75,7 +75,7 @@ entity_impl!(InvokeId, "invoke");
 /// Represents a group invoking either a component or primitive cell, or another group (via a structural enable).
 struct Invoke {
     /// The name of the cell being invoked.
-    name: String,
+    _name: String,
     probe: SignalRef,
     target: InvokeTarget,
     probe_idx: u32,
@@ -107,7 +107,7 @@ impl Design {
     pub fn new(h: &wellen::Hierarchy) -> Result<Self> {
         let main = h
             .lookup_scope(&[&"toplevel", &"main"])
-            .with_context(|| format!("Failed to find main scope"))?;
+            .with_context(|| "Failed to find main scope")?;
         let clk = get_var(h, &h[main], "clk")?;
         let clk = h[clk].signal_ref();
         let mut out = Self {
@@ -151,7 +151,7 @@ impl Design {
     }
 }
 
-pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
+pub fn parse_probe_name(name: &str) -> Result<ProbeName<'_>> {
     let pat = "___";
     if let Some(prefix) = name.strip_suffix("_group_probe") {
         // ex. invoke2UG___main_group_probe
@@ -351,14 +351,14 @@ impl Design {
     fn populate(&mut self, h: &wellen::Hierarchy) -> Result<()> {
         let main_scope = h
             .lookup_scope(&[&"toplevel", &"main"])
-            .with_context(|| format!("Failed to find main scope"))?;
+            .with_context(|| "Failed to find main scope")?;
         let main_go = get_var(h, &h[main_scope], "go")?;
         let main_done = get_var(h, &h[main_scope], "done")?;
         let mut main_cell = Cell {
             name: "main".to_string(),
             groups: smallvec![],
             probes: Some((h[main_go].signal_ref(), h[main_done].signal_ref())),
-            scope: main_scope,
+            _scope: main_scope,
             is_primitive: false,
             instances: smallvec![],
             component: String::new(),
@@ -429,7 +429,7 @@ impl Design {
                             groupid
                         };
                         let invoke_id = self.invokes.push(Invoke {
-                            name: name.to_string(),
+                            _name: name.to_string(),
                             probe,
                             target: InvokeTarget::Group(target),
                             probe_idx: u32::MAX,
@@ -517,11 +517,11 @@ impl Design {
                         let target = if let Some(&t) = maybe_target {
                             t
                         } else {
-                            let scope = get_scope(h, &h[cell_scope], &name)?;
+                            let scope = get_scope(h, &h[cell_scope], name)?;
                             let mut cell_instance = Cell {
                                 name: name.to_string(),
                                 groups: smallvec![],
-                                scope,
+                                _scope: scope,
                                 is_primitive,
                                 instances: smallvec![],
                                 component: String::new(),
@@ -534,7 +534,7 @@ impl Design {
                             cell_id
                         };
                         let invoke_id = self.invokes.push(Invoke {
-                            name: name.to_string(),
+                            _name: name.to_string(),
                             probe,
                             target: InvokeTarget::Cell(target),
                             probe_idx: u32::MAX,

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -1,11 +1,12 @@
 use anyhow::{Context, Result};
 
 use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl};
+use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec};
 use std::path::Prefix;
 use wellen::{Hierarchy, Scope, ScopeRef, SignalRef, VarRef};
 
-use crate::hierarchy;
+use crate::design;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct CellId(u32);
@@ -17,6 +18,8 @@ struct Cell {
     groups: SmallVec<[GroupId; 6]>,
     scope: ScopeRef,
     is_primitive: bool,
+    probe: Option<SignalRef>,
+    probe_idx: Option<u32>,
     component: String,
     /// cells that are defined within the component
     instances: SmallVec<[CellId; 6]>,
@@ -31,6 +34,7 @@ struct Group {
     name: String,
     probe: SignalRef,
     invokes: SmallVec<[InvokeId; 6]>,
+    probe_idx: u32,
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
@@ -42,6 +46,7 @@ struct Invoke {
     name: String,
     probe: SignalRef,
     target: CellId,
+    probe_idx: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -50,15 +55,24 @@ pub struct Design {
     groups: PrimaryMap<GroupId, Group>,
     invokes: PrimaryMap<InvokeId, Invoke>,
     main: CellId,
+    clk: SignalRef,
+    signals: Vec<SignalRef>,
 }
 
 impl Design {
     pub fn new(h: &wellen::Hierarchy) -> Result<Self> {
+        let main = h
+            .lookup_scope(&[&"toplevel", &"main"])
+            .with_context(|| format!("Failed to find main scope"))?;
+        let clk = get_var(h, &h[main], "clk")?;
+        let clk = h[clk].signal_ref();
         let mut out = Self {
             cells: PrimaryMap::new(),
             groups: PrimaryMap::new(),
             invokes: PrimaryMap::new(),
             main: CellId(u32::MAX),
+            clk,
+            signals: vec![],
         };
         out.populate(h)?;
         Ok(out)
@@ -135,6 +149,50 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
 }
 
 impl Design {
+    fn build_idx(&mut self) {
+        self.signals = self.signals();
+        let to_index = FxHashMap::from_iter(
+            self.signals
+                .iter()
+                .enumerate()
+                .map(|(idx, &signal)| (signal, idx as u32)),
+        );
+
+        for (_, cell) in self.cells.iter_mut() {
+            if let Some(p) = cell.probe {
+                cell.probe_idx = Some(to_index[&p]);
+            }
+        }
+
+        for (_, group) in self.groups.iter_mut() {
+            group.probe_idx = to_index[&group.probe];
+        }
+
+        for (_, invoke) in self.invokes.iter_mut() {
+            invoke.probe_idx = to_index[&invoke.probe];
+        }
+    }
+
+    fn signals(&self) -> Vec<SignalRef> {
+        let mut signals = vec![];
+        for cell in self.cells.values() {
+            if let Some(p) = cell.probe {
+                signals.push(p);
+            }
+        }
+
+        for group in self.groups.values() {
+            signals.push(group.probe);
+        }
+
+        for invoke in self.invokes.values() {
+            signals.push(invoke.probe);
+        }
+
+        signals.sort();
+        signals.dedup();
+        signals
+    }
     fn populate(&mut self, h: &wellen::Hierarchy) -> Result<()> {
         let main_scope = h
             .lookup_scope(&[&"toplevel", &"main"])
@@ -143,11 +201,12 @@ impl Design {
         let mut main_cell = Cell {
             name: "main".to_string(),
             groups: smallvec![],
-            // probe: h[main_go].signal_ref(),
+            probe: Some(h[main_go].signal_ref()),
             scope: main_scope,
             is_primitive: false,
             instances: smallvec![],
             component: String::new(),
+            probe_idx: None,
         };
         self.scan_probes(h, main_scope, &mut main_cell)?;
         self.main = self.cells.push(main_cell);
@@ -188,6 +247,7 @@ impl Design {
                             name,
                             probe,
                             invokes,
+                            probe_idx: u32::MAX,
                         });
                         cell.groups.push(groupid);
                     }
@@ -232,6 +292,8 @@ impl Design {
                                 is_primitive,
                                 instances: smallvec![],
                                 component: String::new(),
+                                probe: None,
+                                probe_idx: None,
                             };
                             self.scan_probes(h, scope, &mut cell_instance)?;
                             let cell_id = self.cells.push(cell_instance);
@@ -242,6 +304,7 @@ impl Design {
                             name: name.to_string(),
                             probe,
                             target,
+                            probe_idx: u32::MAX,
                         });
                         if let Some(&group) = maybe_group {
                             self.groups[group].invokes.push(invoke_id);

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -11,24 +11,34 @@ pub struct CellId(u32);
 entity_impl!(CellId, "cell");
 
 #[derive(Clone, Debug)]
-/// Represents
+/// Represents a (component/primitive) cell in the static tree.
 struct Cell {
+    /// The user-defined name of the cell.
     name: String,
+    /// Ids of groups that could be called from this cell, if it is a component.
+    /// NOTE: Primitive cells should have an empty vec here.
     groups: SmallVec<[GroupId; 6]>,
+    /// The scope of the cell in the RTL trace.
     scope: ScopeRef,
+    /// Is the cell a primitive?
     is_primitive: bool,
+    /// If the cell is of the main component, contains a ref to the probe (main.go).
     probe: Option<SignalRef>,
+    /// If the cell is of the main component, contains the bitvector index to the probe (main.go).
     probe_idx: Option<u32>,
+    /// Non-empty if the cell is from a user-defined component.
+    /// FIXME: might be worth pulling the primitive's original name as well?
     component: String,
     /// cells that are defined within the component
     instances: SmallVec<[CellId; 6]>,
 }
 
 impl Cell {
+    /// String representation of cell for trace and visualizations
     pub fn display_name(&self) -> String {
         if self.is_primitive {
             format!("{} (primitive)", self.name)
-        } else if (self.component == "main") {
+        } else if self.component == "main" {
             self.name.clone()
         } else {
             format!("{} [{}]", self.name, self.component)
@@ -50,6 +60,7 @@ struct Group {
 }
 
 impl Group {
+    /// String representation of cell for trace and visualizations
     pub fn display_name(&self) -> String {
         // remove unique group identifier.
         self.name.split("UG").next().unwrap().to_string()
@@ -64,6 +75,7 @@ entity_impl!(InvokeId, "invoke");
 /// Represents a group invoking either a component or primitive cell.
 /// TODO: Should we include structural enables here? If so, the type of target would need to change.
 struct Invoke {
+    /// The name of the cell being invoked.
     name: String,
     probe: SignalRef,
     target: CellId,
@@ -125,17 +137,15 @@ impl Design {
 pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
     let pat = "___";
     if let Some(prefix) = name.strip_suffix("_group_probe") {
-        // invoke2UG___main_group_probe
+        // ex. invoke2UG___main_group_probe
         let mut parts = prefix.split(pat);
-        // let group = parts.next().unwrap().split("UG").next().unwrap();
         let group = parts.next().unwrap();
         let component = parts.next().unwrap();
         Ok(ProbeName::Group { group, component })
     } else if let Some(prefix) = name.strip_suffix("_cell_probe") {
-        // mac___invoke2UG___main_cell_probe
+        // ex. mac___invoke2UG___main_cell_probe
         let mut parts = prefix.split(pat);
         let cell = parts.next().unwrap();
-        // let group = parts.next().unwrap().split("UG").next().unwrap();
         let group = parts.next().unwrap();
         let component = parts.next().unwrap();
         Ok(ProbeName::InvokeCell {
@@ -144,10 +154,9 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
             component,
         })
     } else if let Some(prefix) = name.strip_suffix("_primitive_probe") {
-        //lt0___in_rangeUG___main_primitive_probe
+        // ex. lt0___in_rangeUG___main_primitive_probe
         let mut parts = prefix.split(pat);
         let primitive = parts.next().unwrap();
-        // let group = parts.next().unwrap().split("UG").next().unwrap();
         let group = parts.next().unwrap();
         let component = parts.next().unwrap();
         Ok(ProbeName::InvokePrimitive {
@@ -186,13 +195,8 @@ impl Design {
                 // the invoke probe is active
                 this_thread_prefix.push(target_cell.display_name());
                 if target_cell.is_primitive {
-                    // println!("Primitive {}", target_cell.name);
                     out.push(this_thread_prefix);
                 } else {
-                    // println!(
-                    //     "Cell {} [{}]",
-                    //     target_cell.name, target_cell.component
-                    // );
                     let mut cell_stack = self.compute_cell(
                         value,
                         target_cell_id,
@@ -234,7 +238,7 @@ impl Design {
             }
         }
         // if the cell has groups but none of them are active, we still need to add the cell
-        // NOTE: this is a control cycle.
+        // NOTE: this would be a control cycle.
         if !cell.groups.is_empty() && out.is_empty() {
             out.push(prefix);
         }
@@ -310,6 +314,7 @@ impl Design {
         Ok(())
     }
 
+    /// Constructs the static tree from available probes.
     fn scan_probes(
         &mut self,
         h: &Hierarchy,
@@ -416,12 +421,14 @@ impl Design {
     }
 }
 
+/// Returns a VarRef of the name `name` from the scope `s`, if it exists.
 pub fn get_var(h: &wellen::Hierarchy, s: &Scope, name: &str) -> Result<VarRef> {
     s.vars(h)
         .find(|&v| h[v].name(h) == name)
         .with_context(|| format!("Failed to find {name} in {}", s.full_name(h)))
 }
 
+/// Returns a VarRef of the name `name` from the scope `s`, if it exists.
 pub fn get_scope(
     h: &wellen::Hierarchy,
     s: &Scope,
@@ -433,6 +440,7 @@ pub fn get_scope(
 }
 
 #[derive(PartialEq, Debug)]
+/// Represents a probe name after parsing.
 pub enum ProbeName<'a> {
     Group {
         group: &'a str,

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -1,19 +1,17 @@
 use anyhow::{Context, Result};
 
 use baa::{BitVecOps, BitVecValue};
-use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl};
+use cranelift_entity::{PrimaryMap, entity_impl};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec};
-use std::path::Prefix;
 use wellen::{Hierarchy, Scope, ScopeRef, SignalRef, VarRef};
-
-use crate::design;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct CellId(u32);
 entity_impl!(CellId, "cell");
 
 #[derive(Clone, Debug)]
+/// Represents
 struct Cell {
     name: String,
     groups: SmallVec<[GroupId; 6]>,
@@ -31,6 +29,7 @@ pub struct GroupId(u32);
 entity_impl!(GroupId, "group");
 
 #[derive(Debug, Clone)]
+/// Represents a group activation from a component's control.
 struct Group {
     name: String,
     probe: SignalRef,
@@ -43,6 +42,8 @@ pub struct InvokeId(u32);
 entity_impl!(InvokeId, "invoke");
 
 #[derive(Debug, Clone)]
+/// Represents a group invoking either a component or primitive cell.
+/// TODO: Should we include structural enables here? If so, the type of target would need to change.
 struct Invoke {
     name: String,
     probe: SignalRef,
@@ -51,6 +52,7 @@ struct Invoke {
 }
 
 #[derive(Clone, Debug)]
+/// Represents the static call tree (all possible calls).
 pub struct Design {
     cells: PrimaryMap<CellId, Cell>,
     groups: PrimaryMap<GroupId, Group>,
@@ -92,50 +94,16 @@ impl Design {
         // -> Result<Vec<Vec<String>>> {
         let main = &self.cells[self.main];
         if values.is_bit_set(main.probe_idx.unwrap()) {
-            self.compute_cell(values, self.main);
+            self.compute_cell(values, self.main, vec![]);
         }
         Ok(())
     }
 }
 
-pub fn get_var(h: &wellen::Hierarchy, s: &Scope, name: &str) -> Result<VarRef> {
-    s.vars(h)
-        .find(|&v| h[v].name(h) == name)
-        .with_context(|| format!("Failed to find {name} in {}", s.full_name(h)))
-}
-
-pub fn get_scope(
-    h: &wellen::Hierarchy,
-    s: &Scope,
-    name: &str,
-) -> Result<ScopeRef> {
-    s.scopes(h)
-        .find(|&v| h[v].name(h) == name)
-        .with_context(|| format!("Failed to find {name} in {}", s.full_name(h)))
-}
-
-#[derive(PartialEq, Debug)]
-pub enum ProbeName<'a> {
-    Group {
-        group: &'a str,
-        component: &'a str,
-    },
-    InvokePrimitive {
-        name: &'a str,
-        group: &'a str,
-        component: &'a str,
-    },
-    InvokeCell {
-        name: &'a str,
-        group: &'a str,
-        component: &'a str,
-    },
-}
-
 pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
     let pat = "___";
-    // invoke2UG___main_group_probe
     if let Some(prefix) = name.strip_suffix("_group_probe") {
+        // invoke2UG___main_group_probe
         let mut parts = prefix.split(pat);
         let group = parts.next().unwrap().split("UG").next().unwrap();
         let component = parts.next().unwrap();
@@ -167,7 +135,7 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
     }
 }
 
-// trying to build up the same thing that we have in the python version for now.
+// trying to build up the same thing that we have in pypetal for now.
 pub type Stack = Vec<String>;
 
 impl Design {
@@ -175,24 +143,36 @@ impl Design {
         &self,
         value: &BitVecValue,
         group_id: GroupId,
-        // mut prefix: Stack,
+        mut prefix: Stack,
     ) {
         // ) -> Vec<Stack> {
         let group = &self.groups[group_id];
+        prefix.push(group.name.clone());
+        if group.invokes.is_empty() {
+            println!("No invokes in group {}: {prefix:?}", group.name);
+            return;
+        }
         for &invoke_id in &group.invokes {
+            let mut this_thread_prefix = prefix.clone();
             let invoke = &self.invokes[invoke_id];
             let target_cell_id = invoke.target;
             let target_cell = &self.cells[target_cell_id];
             if value.is_bit_set(invoke.probe_idx) {
                 // the invoke probe is active
                 if target_cell.is_primitive {
-                    println!("Primitive {}", target_cell.name)
+                    // println!("Primitive {}", target_cell.name)
+                    this_thread_prefix.push(target_cell.name.clone());
+                    println!("{this_thread_prefix:?}");
                 } else {
                     println!(
                         "Cell {} [{}]",
                         target_cell.name, target_cell.component
                     );
-                    self.compute_cell(value, target_cell_id)
+                    self.compute_cell(
+                        value,
+                        target_cell_id,
+                        this_thread_prefix.clone(),
+                    )
                 }
             }
         }
@@ -202,24 +182,29 @@ impl Design {
         &self,
         value: &BitVecValue,
         cell_id: CellId,
-        // mut prefix: Stack,
+        mut prefix: Stack,
         // ) -> Vec<Stack> {
     ) {
         let cell = &self.cells[cell_id];
         if let Some(idx) = cell.probe_idx {
             if value.is_bit_set(idx) {
-                println!("Cell {} [{}]", cell.name, cell.component)
+                prefix.push(cell.name.clone());
+                // println!("Cell {} [{}]", cell.name, cell.component)
                 // prefix.push(cell.name.clone());
-                // } else {
-                //     return vec![prefix];
+            } else {
+                return; // vec![prefix];
             }
+        }
+        if cell.groups.is_empty() {
+            // No more children, so this is a sink.
+            println!("{prefix:?}");
         }
         // let mut out = vec![];
         for &group_idx in &cell.groups {
             let group = &self.groups[group_idx];
             if value.is_bit_set(group.probe_idx) {
-                println!("Group {}", group.name);
-                self.compute_group(value, group_idx); // prefix
+                // println!("Group {}", group.name);
+                self.compute_group(value, group_idx, prefix.clone()); // prefix
             }
         }
 
@@ -272,6 +257,7 @@ impl Design {
         signals.dedup();
         signals
     }
+
     fn populate(&mut self, h: &wellen::Hierarchy) -> Result<()> {
         let main_scope = h
             .lookup_scope(&[&"toplevel", &"main"])
@@ -397,6 +383,40 @@ impl Design {
         assert!(parentless_invokes.is_empty());
         Ok(())
     }
+}
+
+pub fn get_var(h: &wellen::Hierarchy, s: &Scope, name: &str) -> Result<VarRef> {
+    s.vars(h)
+        .find(|&v| h[v].name(h) == name)
+        .with_context(|| format!("Failed to find {name} in {}", s.full_name(h)))
+}
+
+pub fn get_scope(
+    h: &wellen::Hierarchy,
+    s: &Scope,
+    name: &str,
+) -> Result<ScopeRef> {
+    s.scopes(h)
+        .find(|&v| h[v].name(h) == name)
+        .with_context(|| format!("Failed to find {name} in {}", s.full_name(h)))
+}
+
+#[derive(PartialEq, Debug)]
+pub enum ProbeName<'a> {
+    Group {
+        group: &'a str,
+        component: &'a str,
+    },
+    InvokePrimitive {
+        name: &'a str,
+        group: &'a str,
+        component: &'a str,
+    },
+    InvokeCell {
+        name: &'a str,
+        group: &'a str,
+        component: &'a str,
+    },
 }
 
 #[cfg(test)]

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -72,22 +72,23 @@ pub struct InvokeId(u32);
 entity_impl!(InvokeId, "invoke");
 
 #[derive(Debug, Clone)]
-/// Represents a group invoking either a component or primitive cell.
-/// TODO: Should we include structural enables here? If so, the type of target would need to change.
+/// Represents a group invoking either a component or primitive cell, or another group (via a structural enable).
 struct Invoke {
     /// The name of the cell being invoked.
     name: String,
     probe: SignalRef,
-    target: CellId,
+    target: InvokeTarget,
     probe_idx: u32,
 }
 
-// TODO: Accommodate structural enables
-// #[derive(Debug, Clone)]
-// enum InvokeTarget {
-//     Cell(CellId),
-//     Group(GroupId),
-// }
+#[derive(Debug, Clone)]
+/// Represents a target of an invoke from a group
+enum InvokeTarget {
+    // Group invokes a component/primitive cell
+    Cell(CellId),
+    // Group invokes a group (structural enable)
+    Group(GroupId),
+}
 
 #[derive(Clone, Debug)]
 /// Represents the static call tree (all possible calls).

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -90,13 +90,17 @@ impl Design {
         self.clk
     }
 
-    pub fn compute(&self, values: &BitVecValue) -> Result<()> {
+    pub fn compute(&self, values: &BitVecValue) -> Result<Vec<Stack>> {
         // -> Result<Vec<Vec<String>>> {
         let main = &self.cells[self.main];
-        if values.is_bit_set(main.probe_idx.unwrap()) {
-            self.compute_cell(values, self.main, vec![]);
+        let main_active = values.is_bit_set(main.probe_idx.unwrap());
+        let mut stacks = vec![];
+        if main_active {
+            stacks = self.compute_cell(values, self.main, vec![]);
+            stacks.sort();
+            stacks.dedup();
         }
-        Ok(())
+        Ok(stacks)
     }
 }
 
@@ -144,14 +148,15 @@ impl Design {
         value: &BitVecValue,
         group_id: GroupId,
         mut prefix: Stack,
-    ) {
-        // ) -> Vec<Stack> {
+    ) -> Vec<Stack> {
+        // assumes that the group is active (otherwise this function would not be called.)
         let group = &self.groups[group_id];
         prefix.push(group.name.clone());
         if group.invokes.is_empty() {
             println!("No invokes in group {}: {prefix:?}", group.name);
-            return;
+            return vec![prefix];
         }
+        let mut out: Vec<Stack> = vec![];
         for &invoke_id in &group.invokes {
             let mut this_thread_prefix = prefix.clone();
             let invoke = &self.invokes[invoke_id];
@@ -159,23 +164,26 @@ impl Design {
             let target_cell = &self.cells[target_cell_id];
             if value.is_bit_set(invoke.probe_idx) {
                 // the invoke probe is active
+                this_thread_prefix.push(target_cell.name.clone());
                 if target_cell.is_primitive {
                     // println!("Primitive {}", target_cell.name)
-                    this_thread_prefix.push(target_cell.name.clone());
-                    println!("{this_thread_prefix:?}");
+                    out.push(this_thread_prefix);
+                    // println!("{this_thread_prefix:?}");
                 } else {
-                    println!(
-                        "Cell {} [{}]",
-                        target_cell.name, target_cell.component
-                    );
-                    self.compute_cell(
+                    // println!(
+                    //     "Cell {} [{}]",
+                    //     target_cell.name, target_cell.component
+                    // );
+                    let mut cell_stack = self.compute_cell(
                         value,
                         target_cell_id,
                         this_thread_prefix.clone(),
-                    )
+                    );
+                    out.append(&mut cell_stack);
                 }
             }
         }
+        out
     }
 
     fn compute_cell(
@@ -183,32 +191,32 @@ impl Design {
         value: &BitVecValue,
         cell_id: CellId,
         mut prefix: Stack,
-        // ) -> Vec<Stack> {
-    ) {
+    ) -> Vec<Stack> {
         let cell = &self.cells[cell_id];
         if let Some(idx) = cell.probe_idx {
+            // the main component cell is the only one to have a probe_idx.
             if value.is_bit_set(idx) {
                 prefix.push(cell.name.clone());
-                // println!("Cell {} [{}]", cell.name, cell.component)
-                // prefix.push(cell.name.clone());
             } else {
-                return; // vec![prefix];
+                return vec![prefix];
             }
         }
         if cell.groups.is_empty() {
             // No more children, so this is a sink.
-            println!("{prefix:?}");
+            return vec![prefix];
         }
-        // let mut out = vec![];
+        let mut out = vec![];
         for &group_idx in &cell.groups {
             let group = &self.groups[group_idx];
             if value.is_bit_set(group.probe_idx) {
                 // println!("Group {}", group.name);
-                self.compute_group(value, group_idx, prefix.clone()); // prefix
+                let mut group_stacks =
+                    self.compute_group(value, group_idx, prefix.clone());
+                out.append(&mut group_stacks);
             }
         }
 
-        // out
+        out
     }
 
     fn build_idx(&mut self) {

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -614,7 +614,7 @@ mod tests {
         assert_eq!(
             parse_probe_name("invoke2UG___main_group_probe").unwrap(),
             ProbeName::Group {
-                group: "invoke2",
+                group: "invoke2UG",
                 component: "main"
             }
         );
@@ -622,7 +622,7 @@ mod tests {
             parse_probe_name("mac___invoke2UG___main_cell_probe").unwrap(),
             ProbeName::InvokeCell {
                 name: "mac",
-                group: "invoke2",
+                group: "invoke2UG",
                 component: "main"
             }
         );
@@ -631,7 +631,15 @@ mod tests {
                 .unwrap(),
             ProbeName::InvokePrimitive {
                 name: "lt0",
-                group: "in_range",
+                group: "in_rangeUG",
+                component: "main"
+            }
+        );
+        assert_eq!(
+            parse_probe_name("wr_a___wr_b___main_se_probe").unwrap(),
+            ProbeName::InvokeGroup {
+                name: "wr_a",
+                group: "wr_b",
                 component: "main"
             }
         );

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -121,7 +121,12 @@ impl Design {
         self.clk
     }
 
-    pub fn compute(&self, values: &BitVecValue) -> Result<Vec<Stack>> {
+    /// Computes the active call tree from a cycle, represented as a list of stacks (Python Petal style).
+    /// values is the probe signals bitvector obtained from the cycle in question.
+    pub fn compute_cycle_trace(
+        &self,
+        values: &BitVecValue,
+    ) -> Result<Vec<Stack>> {
         let main = &self.cells[self.main];
         let main_active = values.is_bit_set(main.probe_idx.unwrap());
         let mut stacks = vec![];
@@ -173,42 +178,9 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
 pub type Stack = Vec<String>;
 
 impl Design {
-    fn compute_group(
-        &self,
-        value: &BitVecValue,
-        group_id: GroupId,
-        mut prefix: Stack,
-    ) -> Vec<Stack> {
-        // assumes that the group is active (otherwise this function would not be called.)
-        let group = &self.groups[group_id];
-        prefix.push(group.display_name());
-        if group.invokes.is_empty() {
-            return vec![prefix];
-        }
-        let mut out: Vec<Stack> = vec![];
-        for &invoke_id in &group.invokes {
-            let mut this_thread_prefix = prefix.clone();
-            let invoke = &self.invokes[invoke_id];
-            let target_cell_id = invoke.target;
-            let target_cell = &self.cells[target_cell_id];
-            if value.is_bit_set(invoke.probe_idx) {
-                // the invoke probe is active
-                this_thread_prefix.push(target_cell.display_name());
-                if target_cell.is_primitive {
-                    out.push(this_thread_prefix);
-                } else {
-                    let mut cell_stack = self.compute_cell(
-                        value,
-                        target_cell_id,
-                        this_thread_prefix.clone(),
-                    );
-                    out.append(&mut cell_stack);
-                }
-            }
-        }
-        out
-    }
-
+    /// Builds up all active tree paths this cycle from the cell of cell_id.
+    /// prefix is the state of the stack before this particular cell.
+    /// NOTE: This function is co-recursive with compute_group().
     fn compute_cell(
         &self,
         value: &BitVecValue,
@@ -246,8 +218,48 @@ impl Design {
         out
     }
 
+    /// Builds up all active tree paths this cycle from the group of group_id.
+    /// prefix is the state of the stack before this particular group.
+    /// NOTE: This function is co-recursive with compute_cell(), and only called when
+    /// the group is active (otherwise this function would not be called.)
+    fn compute_group(
+        &self,
+        value: &BitVecValue,
+        group_id: GroupId,
+        mut prefix: Stack,
+    ) -> Vec<Stack> {
+        let group = &self.groups[group_id];
+        prefix.push(group.display_name());
+        if group.invokes.is_empty() {
+            return vec![prefix];
+        }
+        let mut out: Vec<Stack> = vec![];
+        for &invoke_id in &group.invokes {
+            let mut this_thread_prefix = prefix.clone();
+            let invoke = &self.invokes[invoke_id];
+            let target_cell_id = invoke.target;
+            let target_cell = &self.cells[target_cell_id];
+            if value.is_bit_set(invoke.probe_idx) {
+                // the invoke probe is active
+                this_thread_prefix.push(target_cell.display_name());
+                if target_cell.is_primitive {
+                    out.push(this_thread_prefix);
+                } else {
+                    let mut cell_stack = self.compute_cell(
+                        value,
+                        target_cell_id,
+                        this_thread_prefix.clone(),
+                    );
+                    out.append(&mut cell_stack);
+                }
+            }
+        }
+        out
+    }
+
+    /// Maps between probes and their indices in self.signals().
     fn build_idx(&mut self) {
-        self.signals = self.signals();
+        self.signals = self.probe_signals();
         let to_index = FxHashMap::from_iter(
             self.signals
                 .iter()
@@ -270,7 +282,8 @@ impl Design {
         }
     }
 
-    fn signals(&self) -> Vec<SignalRef> {
+    /// Helper for build_idx() to obtain all probe signals.
+    fn probe_signals(&self) -> Vec<SignalRef> {
         let mut signals = vec![];
         for cell in self.cells.values() {
             if let Some(p) = cell.probe {
@@ -293,6 +306,7 @@ impl Design {
         signals
     }
 
+    /// Builds the static call tree by scanning through all probes to find tree edges.
     fn populate(&mut self, h: &wellen::Hierarchy) -> Result<()> {
         let main_scope = h
             .lookup_scope(&[&"toplevel", &"main"])

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -366,8 +366,6 @@ impl Design {
         };
         self.scan_probes(h, main_scope, &mut main_cell)?;
         self.main = self.cells.push(main_cell);
-        println!("{self:?}");
-
         Ok(())
     }
 
@@ -384,6 +382,75 @@ impl Design {
         // collection of all groups within this cell. Will filter out those in structurally_invoked_groups
         let mut all_groups: Vec<GroupId> = vec![];
         let mut parentless_invokes: Vec<(&str, InvokeId)> = vec![];
+        // First pass approach: Iterate through all structural enables first to prevent creating duplicate group entries.
+        // (structurally enabled groups have two probes; the structural enable probe and the group active probe.)
+        for probe_scope in h[cell_scope].scopes(h) {
+            let name = h[probe_scope].name(h);
+            if name.ends_with("_se_probe") {
+                // only grabbing structural enables
+                let out = get_var(h, &h[probe_scope], "out")?;
+                let probe = h[out].signal_ref();
+                let probe_name = parse_probe_name(name)?;
+                match probe_name {
+                    ProbeName::InvokeGroup {
+                        name,
+                        group,
+                        component,
+                    } => {
+                        assert!(
+                            cell.component.is_empty()
+                                || cell.component == component
+                        );
+                        if cell.component.is_empty() {
+                            cell.component = component.to_string();
+                        }
+                        // check for the target group, and create it if it does not exist.
+                        let maybe_target_group = all_groups
+                            .iter()
+                            .find(|&&g| self.groups[g].name == name);
+                        let target = if let Some(&t) = maybe_target_group {
+                            t
+                        } else {
+                            let invokes = parentless_invokes
+                                .extract_if(.., |(group_name, _)| {
+                                    group_name == &name
+                                })
+                                .map(|(_, ii)| ii)
+                                .collect();
+                            let groupid = self.groups.push(Group {
+                                name: name.to_string(),
+                                probe,
+                                invokes,
+                                probe_idx: u32::MAX,
+                            });
+                            all_groups.push(groupid);
+                            structurally_invoked_group_names
+                                .push(name.to_string());
+                            groupid
+                        };
+                        let invoke_id = self.invokes.push(Invoke {
+                            name: name.to_string(),
+                            probe,
+                            target: InvokeTarget::Group(target),
+                            probe_idx: u32::MAX,
+                        });
+                        // Check for the caller group, and add an Invoke entry if it exists.
+                        let maybe_caller_group = all_groups
+                            .iter()
+                            .find(|&&g| self.groups[g].name == group);
+                        if let Some(&group) = maybe_caller_group {
+                            self.groups[group].invokes.push(invoke_id);
+                        } else {
+                            parentless_invokes.push((group, invoke_id))
+                        }
+                    }
+                    _ => {
+                        panic!("{name} should be a structural enable probe!")
+                    }
+                }
+            }
+        }
+        // iterate through all probes in this scope. Structural enable probes will be ignored as they were previously
         for probe_scope in h[cell_scope].scopes(h) {
             let name = h[probe_scope].name(h);
             if name.ends_with("_probe") {
@@ -406,64 +473,16 @@ impl Design {
                             })
                             .map(|(_, ii)| ii)
                             .collect();
-                        let groupid = self.groups.push(Group {
-                            name,
-                            probe,
-                            invokes,
-                            probe_idx: u32::MAX,
-                        });
-                        all_groups.push(groupid);
-                    }
-                    ProbeName::InvokeGroup {
-                        name,
-                        group,
-                        component,
-                    } => {
-                        assert!(
-                            cell.component.is_empty()
-                                || cell.component == component
-                        );
-                        if cell.component.is_empty() {
-                            cell.component = component.to_string();
-                        }
-                        // check for the target group, and create it if it does not exist.
-                        let maybe_target_group = cell
-                            .groups
-                            .iter()
-                            .find(|&&g| self.groups[g].name == name);
-                        let target = if let Some(&t) = maybe_target_group {
-                            t
-                        } else {
-                            let invokes = parentless_invokes
-                                .extract_if(.., |(group_name, _)| {
-                                    group_name == &name
-                                })
-                                .map(|(_, ii)| ii)
-                                .collect();
+                        if !structurally_invoked_group_names.contains(&name) {
+                            // only create a group entry if this group was not structurally enabled.
                             let groupid = self.groups.push(Group {
-                                name: name.to_string(),
+                                name,
                                 probe,
                                 invokes,
                                 probe_idx: u32::MAX,
                             });
-                            structurally_invoked_group_names
-                                .push(name.to_string());
-                            groupid
-                        };
-                        let invoke_id = self.invokes.push(Invoke {
-                            name: name.to_string(),
-                            probe,
-                            target: InvokeTarget::Group(target),
-                            probe_idx: u32::MAX,
-                        });
-                        // Check for the caller group, and add an Invoke entry if it exists.
-                        let maybe_caller_group = all_groups
-                            .iter()
-                            .find(|&&g| self.groups[g].name == group);
-                        if let Some(&group) = maybe_caller_group {
-                            self.groups[group].invokes.push(invoke_id);
-                        } else {
-                            parentless_invokes.push((group, invoke_id))
+                            cell.groups.push(groupid);
+                            all_groups.push(groupid);
                         }
                     }
                     ProbeName::InvokePrimitive {
@@ -526,26 +545,17 @@ impl Design {
                             parentless_invokes.push((group, invoke_id))
                         }
                     }
+                    ProbeName::InvokeGroup {
+                        name: _,
+                        group: _,
+                        component: _,
+                    } => {
+                        // we iterated through all structural enables at the beginning, so we will skip those here.
+                        continue;
+                    }
                 }
             }
         }
-        // Only add groups that are NOT structurally enabled to cell.groups
-        // so that there is no edge from the component cell to any structurally enabled group.
-        println!(
-            "structurally invoked groups: {structurally_invoked_group_names:?}"
-        );
-        for &g in all_groups.iter().filter(|&&g| {
-            !structurally_invoked_group_names.contains(&self.groups[g].name)
-        }) {
-            cell.groups.push(g);
-        }
-        // cell.groups.push(groupid);
-        // let all_groups = cell.groups.clone();
-        // cell.groups = all_groups
-        //     .iter()
-        //     .filter(|&&g| !structurally_invoked_groups.contains(&g))
-        //     .collect();
-        println!("{parentless_invokes:?}");
         assert!(parentless_invokes.is_empty());
         Ok(())
     }

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 
+use baa::{BitVecOps, BitVecValue};
 use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec};
@@ -75,7 +76,25 @@ impl Design {
             signals: vec![],
         };
         out.populate(h)?;
+        out.build_idx();
         Ok(out)
+    }
+
+    pub fn get_signals(&self) -> Vec<SignalRef> {
+        self.signals.clone()
+    }
+
+    pub fn clk(&self) -> SignalRef {
+        self.clk
+    }
+
+    pub fn compute(&self, values: &BitVecValue) -> Result<()> {
+        // -> Result<Vec<Vec<String>>> {
+        let main = &self.cells[self.main];
+        if values.is_bit_set(main.probe_idx.unwrap()) {
+            self.compute_cell(values, self.main);
+        }
+        Ok(())
     }
 }
 
@@ -148,7 +167,65 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
     }
 }
 
+// trying to build up the same thing that we have in the python version for now.
+pub type Stack = Vec<String>;
+
 impl Design {
+    fn compute_group(
+        &self,
+        value: &BitVecValue,
+        group_id: GroupId,
+        // mut prefix: Stack,
+    ) {
+        // ) -> Vec<Stack> {
+        let group = &self.groups[group_id];
+        for &invoke_id in &group.invokes {
+            let invoke = &self.invokes[invoke_id];
+            let target_cell_id = invoke.target;
+            let target_cell = &self.cells[target_cell_id];
+            if value.is_bit_set(invoke.probe_idx) {
+                // the invoke probe is active
+                if target_cell.is_primitive {
+                    println!("Primitive {}", target_cell.name)
+                } else {
+                    println!(
+                        "Cell {} [{}]",
+                        target_cell.name, target_cell.component
+                    );
+                    self.compute_cell(value, target_cell_id)
+                }
+            }
+        }
+    }
+
+    fn compute_cell(
+        &self,
+        value: &BitVecValue,
+        cell_id: CellId,
+        // mut prefix: Stack,
+        // ) -> Vec<Stack> {
+    ) {
+        let cell = &self.cells[cell_id];
+        if let Some(idx) = cell.probe_idx {
+            if value.is_bit_set(idx) {
+                println!("Cell {} [{}]", cell.name, cell.component)
+                // prefix.push(cell.name.clone());
+                // } else {
+                //     return vec![prefix];
+            }
+        }
+        // let mut out = vec![];
+        for &group_idx in &cell.groups {
+            let group = &self.groups[group_idx];
+            if value.is_bit_set(group.probe_idx) {
+                println!("Group {}", group.name);
+                self.compute_group(value, group_idx); // prefix
+            }
+        }
+
+        // out
+    }
+
     fn build_idx(&mut self) {
         self.signals = self.signals();
         let to_index = FxHashMap::from_iter(
@@ -188,6 +265,8 @@ impl Design {
         for invoke in self.invokes.values() {
             signals.push(invoke.probe);
         }
+
+        signals.push(self.clk);
 
         signals.sort();
         signals.dedup();

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -24,6 +24,18 @@ struct Cell {
     instances: SmallVec<[CellId; 6]>,
 }
 
+impl Cell {
+    pub fn display_name(&self) -> String {
+        if self.is_primitive {
+            format!("{} (primitive)", self.name)
+        } else if (self.component == "main") {
+            self.name.clone()
+        } else {
+            format!("{} [{}]", self.name, self.component)
+        }
+    }
+}
+
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct GroupId(u32);
 entity_impl!(GroupId, "group");
@@ -35,6 +47,13 @@ struct Group {
     probe: SignalRef,
     invokes: SmallVec<[InvokeId; 6]>,
     probe_idx: u32,
+}
+
+impl Group {
+    pub fn display_name(&self) -> String {
+        // remove unique group identifier.
+        self.name.split("UG").next().unwrap().to_string()
+    }
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
@@ -91,7 +110,6 @@ impl Design {
     }
 
     pub fn compute(&self, values: &BitVecValue) -> Result<Vec<Stack>> {
-        // -> Result<Vec<Vec<String>>> {
         let main = &self.cells[self.main];
         let main_active = values.is_bit_set(main.probe_idx.unwrap());
         let mut stacks = vec![];
@@ -109,14 +127,16 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
     if let Some(prefix) = name.strip_suffix("_group_probe") {
         // invoke2UG___main_group_probe
         let mut parts = prefix.split(pat);
-        let group = parts.next().unwrap().split("UG").next().unwrap();
+        // let group = parts.next().unwrap().split("UG").next().unwrap();
+        let group = parts.next().unwrap();
         let component = parts.next().unwrap();
         Ok(ProbeName::Group { group, component })
     } else if let Some(prefix) = name.strip_suffix("_cell_probe") {
         // mac___invoke2UG___main_cell_probe
         let mut parts = prefix.split(pat);
         let cell = parts.next().unwrap();
-        let group = parts.next().unwrap().split("UG").next().unwrap();
+        // let group = parts.next().unwrap().split("UG").next().unwrap();
+        let group = parts.next().unwrap();
         let component = parts.next().unwrap();
         Ok(ProbeName::InvokeCell {
             name: cell,
@@ -127,7 +147,8 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
         //lt0___in_rangeUG___main_primitive_probe
         let mut parts = prefix.split(pat);
         let primitive = parts.next().unwrap();
-        let group = parts.next().unwrap().split("UG").next().unwrap();
+        // let group = parts.next().unwrap().split("UG").next().unwrap();
+        let group = parts.next().unwrap();
         let component = parts.next().unwrap();
         Ok(ProbeName::InvokePrimitive {
             name: primitive,
@@ -151,9 +172,8 @@ impl Design {
     ) -> Vec<Stack> {
         // assumes that the group is active (otherwise this function would not be called.)
         let group = &self.groups[group_id];
-        prefix.push(group.name.clone());
+        prefix.push(group.display_name());
         if group.invokes.is_empty() {
-            println!("No invokes in group {}: {prefix:?}", group.name);
             return vec![prefix];
         }
         let mut out: Vec<Stack> = vec![];
@@ -164,11 +184,10 @@ impl Design {
             let target_cell = &self.cells[target_cell_id];
             if value.is_bit_set(invoke.probe_idx) {
                 // the invoke probe is active
-                this_thread_prefix.push(target_cell.name.clone());
+                this_thread_prefix.push(target_cell.display_name());
                 if target_cell.is_primitive {
-                    // println!("Primitive {}", target_cell.name)
+                    // println!("Primitive {}", target_cell.name);
                     out.push(this_thread_prefix);
-                    // println!("{this_thread_prefix:?}");
                 } else {
                     // println!(
                     //     "Cell {} [{}]",
@@ -196,7 +215,7 @@ impl Design {
         if let Some(idx) = cell.probe_idx {
             // the main component cell is the only one to have a probe_idx.
             if value.is_bit_set(idx) {
-                prefix.push(cell.name.clone());
+                prefix.push(cell.display_name());
             } else {
                 return vec![prefix];
             }
@@ -209,11 +228,15 @@ impl Design {
         for &group_idx in &cell.groups {
             let group = &self.groups[group_idx];
             if value.is_bit_set(group.probe_idx) {
-                // println!("Group {}", group.name);
                 let mut group_stacks =
                     self.compute_group(value, group_idx, prefix.clone());
                 out.append(&mut group_stacks);
             }
+        }
+        // if the cell has groups but none of them are active, we still need to add the cell
+        // NOTE: this is a control cycle.
+        if !cell.groups.is_empty() && out.is_empty() {
+            out.push(prefix);
         }
 
         out

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -377,9 +377,10 @@ impl Design {
         cell: &mut Cell,
     ) -> Result<()> {
         // cell.groups should not contain any structurally enabled groups.
-        // So, we will hold all of the structurally enabled groups, and only add to cell.groups
+        // So, we will record all names of structurally invoked groups so later we can prevent cell.groups from
+        // containing any groups with such names.
         let mut structurally_invoked_group_names: Vec<String> = vec![];
-        // collection of all groups within this cell. Will filter out those in structurally_invoked_groups
+        // collection of all groups defined within this cell. Will filter out those in structurally_invoked_groups
         let mut all_groups: Vec<GroupId> = vec![];
         let mut parentless_invokes: Vec<(&str, InvokeId)> = vec![];
         // First pass approach: Iterate through all structural enables first to prevent creating duplicate group entries.
@@ -450,7 +451,7 @@ impl Design {
                 }
             }
         }
-        // iterate through all probes in this scope. Structural enable probes will be ignored as they were previously
+        // iterate through all probes in this scope. Structural enable probes will be ignored as nodes for them were previously created.
         for probe_scope in h[cell_scope].scopes(h) {
             let name = h[probe_scope].name(h);
             if name.ends_with("_probe") {

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -94,6 +94,8 @@ enum InvokeTarget {
 /// Represents the static call tree (all possible calls).
 pub struct Design {
     cells: PrimaryMap<CellId, Cell>,
+    /// groups that are activated from control
+    /// NOTE: Does not include groups that are activated via structural enables.
     groups: PrimaryMap<GroupId, Group>,
     invokes: PrimaryMap<InvokeId, Invoke>,
     main: CellId,
@@ -179,6 +181,17 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
             group,
             component,
         })
+    } else if let Some(prefix) = name.strip_suffix("_se_probe") {
+        // ex. wr_a___wr_b___main_se_probe
+        let mut parts = prefix.split(pat);
+        let enabled_group = parts.next().unwrap();
+        let caller_group = parts.next().unwrap();
+        let component = parts.next().unwrap();
+        Ok(ProbeName::InvokeGroup {
+            name: enabled_group,
+            group: caller_group,
+            component,
+        })
     } else {
         anyhow::bail!("failed to parse {name}")
     }
@@ -248,20 +261,33 @@ impl Design {
         for &invoke_id in &group.invokes {
             let mut this_thread_prefix = prefix.clone();
             let invoke = &self.invokes[invoke_id];
-            let target_cell_id = invoke.target;
-            let target_cell = &self.cells[target_cell_id];
             if value.is_bit_set(invoke.probe_idx) {
                 // the invoke probe is active
-                this_thread_prefix.push(target_cell.display_name());
-                if target_cell.is_primitive {
-                    out.push(this_thread_prefix);
-                } else {
-                    let mut cell_stack = self.compute_cell(
-                        value,
-                        target_cell_id,
-                        this_thread_prefix.clone(),
-                    );
-                    out.append(&mut cell_stack);
+                match invoke.target {
+                    InvokeTarget::Cell(target_cell_id) => {
+                        // component or primitive cell activation
+                        let target_cell = &self.cells[target_cell_id];
+                        this_thread_prefix.push(target_cell.display_name());
+                        if target_cell.is_primitive {
+                            out.push(this_thread_prefix);
+                        } else {
+                            let mut cell_stacks = self.compute_cell(
+                                value,
+                                target_cell_id,
+                                this_thread_prefix.clone(),
+                            );
+                            out.append(&mut cell_stacks);
+                        }
+                    }
+                    InvokeTarget::Group(target_group_id) => {
+                        // structural enable (group enables another group)
+                        let mut group_stacks = self.compute_group(
+                            value,
+                            target_group_id,
+                            this_thread_prefix.clone(),
+                        );
+                        out.append(&mut group_stacks);
+                    }
                 }
             }
         }
@@ -340,6 +366,7 @@ impl Design {
         };
         self.scan_probes(h, main_scope, &mut main_cell)?;
         self.main = self.cells.push(main_cell);
+        println!("{self:?}");
 
         Ok(())
     }
@@ -351,6 +378,11 @@ impl Design {
         cell_scope: ScopeRef,
         cell: &mut Cell,
     ) -> Result<()> {
+        // cell.groups should not contain any structurally enabled groups.
+        // So, we will hold all of the structurally enabled groups, and only add to cell.groups
+        let mut structurally_invoked_group_names: Vec<String> = vec![];
+        // collection of all groups within this cell. Will filter out those in structurally_invoked_groups
+        let mut all_groups: Vec<GroupId> = vec![];
         let mut parentless_invokes: Vec<(&str, InvokeId)> = vec![];
         for probe_scope in h[cell_scope].scopes(h) {
             let name = h[probe_scope].name(h);
@@ -380,7 +412,59 @@ impl Design {
                             invokes,
                             probe_idx: u32::MAX,
                         });
-                        cell.groups.push(groupid);
+                        all_groups.push(groupid);
+                    }
+                    ProbeName::InvokeGroup {
+                        name,
+                        group,
+                        component,
+                    } => {
+                        assert!(
+                            cell.component.is_empty()
+                                || cell.component == component
+                        );
+                        if cell.component.is_empty() {
+                            cell.component = component.to_string();
+                        }
+                        // check for the target group, and create it if it does not exist.
+                        let maybe_target_group = cell
+                            .groups
+                            .iter()
+                            .find(|&&g| self.groups[g].name == name);
+                        let target = if let Some(&t) = maybe_target_group {
+                            t
+                        } else {
+                            let invokes = parentless_invokes
+                                .extract_if(.., |(group_name, _)| {
+                                    group_name == &name
+                                })
+                                .map(|(_, ii)| ii)
+                                .collect();
+                            let groupid = self.groups.push(Group {
+                                name: name.to_string(),
+                                probe,
+                                invokes,
+                                probe_idx: u32::MAX,
+                            });
+                            structurally_invoked_group_names
+                                .push(name.to_string());
+                            groupid
+                        };
+                        let invoke_id = self.invokes.push(Invoke {
+                            name: name.to_string(),
+                            probe,
+                            target: InvokeTarget::Group(target),
+                            probe_idx: u32::MAX,
+                        });
+                        // Check for the caller group, and add an Invoke entry if it exists.
+                        let maybe_caller_group = all_groups
+                            .iter()
+                            .find(|&&g| self.groups[g].name == group);
+                        if let Some(&group) = maybe_caller_group {
+                            self.groups[group].invokes.push(invoke_id);
+                        } else {
+                            parentless_invokes.push((group, invoke_id))
+                        }
                     }
                     ProbeName::InvokePrimitive {
                         name,
@@ -392,19 +476,18 @@ impl Design {
                         group,
                         component,
                     } => {
-                        let is_primitive = matches!(
-                            probe_name,
-                            ProbeName::InvokePrimitive { .. }
-                        );
                         assert!(
                             cell.component.is_empty()
                                 || cell.component == component
                         );
+                        let is_primitive = matches!(
+                            probe_name,
+                            ProbeName::InvokePrimitive { .. }
+                        );
                         if cell.component.is_empty() {
                             cell.component = component.to_string();
                         }
-                        let maybe_group = cell
-                            .groups
+                        let maybe_group = all_groups
                             .iter()
                             .find(|&&g| self.groups[g].name == group);
                         // create target cell.
@@ -434,7 +517,7 @@ impl Design {
                         let invoke_id = self.invokes.push(Invoke {
                             name: name.to_string(),
                             probe,
-                            target,
+                            target: InvokeTarget::Cell(target),
                             probe_idx: u32::MAX,
                         });
                         if let Some(&group) = maybe_group {
@@ -446,6 +529,23 @@ impl Design {
                 }
             }
         }
+        // Only add groups that are NOT structurally enabled to cell.groups
+        // so that there is no edge from the component cell to any structurally enabled group.
+        println!(
+            "structurally invoked groups: {structurally_invoked_group_names:?}"
+        );
+        for &g in all_groups.iter().filter(|&&g| {
+            !structurally_invoked_group_names.contains(&self.groups[g].name)
+        }) {
+            cell.groups.push(g);
+        }
+        // cell.groups.push(groupid);
+        // let all_groups = cell.groups.clone();
+        // cell.groups = all_groups
+        //     .iter()
+        //     .filter(|&&g| !structurally_invoked_groups.contains(&g))
+        //     .collect();
+        println!("{parentless_invokes:?}");
         assert!(parentless_invokes.is_empty());
         Ok(())
     }
@@ -483,6 +583,13 @@ pub enum ProbeName<'a> {
     },
     InvokeCell {
         name: &'a str,
+        group: &'a str,
+        component: &'a str,
+    },
+    InvokeGroup {
+        // group that is invoked
+        name: &'a str,
+        // group that does the invoking
         group: &'a str,
         component: &'a str,
     },

--- a/tools/petal/src/hierarchy.rs
+++ b/tools/petal/src/hierarchy.rs
@@ -1,0 +1,291 @@
+use anyhow::{Context, Result};
+
+use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl};
+use smallvec::{SmallVec, smallvec};
+use std::path::Prefix;
+use wellen::{Hierarchy, Scope, ScopeRef, SignalRef, VarRef};
+
+use crate::hierarchy;
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+pub struct CellId(u32);
+entity_impl!(CellId, "cell");
+
+#[derive(Clone, Debug)]
+struct Cell {
+    name: String,
+    groups: SmallVec<[GroupId; 6]>,
+    scope: ScopeRef,
+    is_primitive: bool,
+    component: String,
+    /// cells that are defined within the component
+    instances: SmallVec<[CellId; 6]>,
+}
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+pub struct GroupId(u32);
+entity_impl!(GroupId, "group");
+
+#[derive(Debug, Clone)]
+struct Group {
+    name: String,
+    probe: SignalRef,
+    invokes: SmallVec<[InvokeId; 6]>,
+}
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+pub struct InvokeId(u32);
+entity_impl!(InvokeId, "invoke");
+
+#[derive(Debug, Clone)]
+struct Invoke {
+    name: String,
+    probe: SignalRef,
+    target: CellId,
+}
+
+#[derive(Clone, Debug)]
+pub struct Design {
+    cells: PrimaryMap<CellId, Cell>,
+    groups: PrimaryMap<GroupId, Group>,
+    invokes: PrimaryMap<InvokeId, Invoke>,
+    main: CellId,
+}
+
+impl Design {
+    pub fn new(h: &wellen::Hierarchy) -> Result<Self> {
+        let mut out = Self {
+            cells: PrimaryMap::new(),
+            groups: PrimaryMap::new(),
+            invokes: PrimaryMap::new(),
+            main: CellId(u32::MAX),
+        };
+        out.populate(h)?;
+        Ok(out)
+    }
+}
+
+pub fn get_var(h: &wellen::Hierarchy, s: &Scope, name: &str) -> Result<VarRef> {
+    s.vars(h)
+        .find(|&v| h[v].name(h) == name)
+        .with_context(|| format!("Failed to find {name} in {}", s.full_name(h)))
+}
+
+pub fn get_scope(
+    h: &wellen::Hierarchy,
+    s: &Scope,
+    name: &str,
+) -> Result<ScopeRef> {
+    s.scopes(h)
+        .find(|&v| h[v].name(h) == name)
+        .with_context(|| format!("Failed to find {name} in {}", s.full_name(h)))
+}
+
+#[derive(PartialEq, Debug)]
+pub enum ProbeName<'a> {
+    Group {
+        group: &'a str,
+        component: &'a str,
+    },
+    InvokePrimitive {
+        name: &'a str,
+        group: &'a str,
+        component: &'a str,
+    },
+    InvokeCell {
+        name: &'a str,
+        group: &'a str,
+        component: &'a str,
+    },
+}
+
+pub fn parse_probe_name(name: &str) -> Result<ProbeName> {
+    let pat = "___";
+    // invoke2UG___main_group_probe
+    if let Some(prefix) = name.strip_suffix("_group_probe") {
+        let mut parts = prefix.split(pat);
+        let group = parts.next().unwrap().split("UG").next().unwrap();
+        let component = parts.next().unwrap();
+        Ok(ProbeName::Group { group, component })
+    } else if let Some(prefix) = name.strip_suffix("_cell_probe") {
+        // mac___invoke2UG___main_cell_probe
+        let mut parts = prefix.split(pat);
+        let cell = parts.next().unwrap();
+        let group = parts.next().unwrap().split("UG").next().unwrap();
+        let component = parts.next().unwrap();
+        Ok(ProbeName::InvokeCell {
+            name: cell,
+            group,
+            component,
+        })
+    } else if let Some(prefix) = name.strip_suffix("_primitive_probe") {
+        //lt0___in_rangeUG___main_primitive_probe
+        let mut parts = prefix.split(pat);
+        let primitive = parts.next().unwrap();
+        let group = parts.next().unwrap().split("UG").next().unwrap();
+        let component = parts.next().unwrap();
+        Ok(ProbeName::InvokePrimitive {
+            name: primitive,
+            group,
+            component,
+        })
+    } else {
+        anyhow::bail!("failed to parse {name}")
+    }
+}
+
+impl Design {
+    fn populate(&mut self, h: &wellen::Hierarchy) -> Result<()> {
+        let main_scope = h
+            .lookup_scope(&[&"toplevel", &"main"])
+            .with_context(|| format!("Failed to find main scope"))?;
+        let main_go = get_var(h, &h[main_scope], "go")?;
+        let mut main_cell = Cell {
+            name: "main".to_string(),
+            groups: smallvec![],
+            // probe: h[main_go].signal_ref(),
+            scope: main_scope,
+            is_primitive: false,
+            instances: smallvec![],
+            component: String::new(),
+        };
+        self.scan_probes(h, main_scope, &mut main_cell)?;
+        self.main = self.cells.push(main_cell);
+
+        Ok(())
+    }
+
+    fn scan_probes(
+        &mut self,
+        h: &Hierarchy,
+        cell_scope: ScopeRef,
+        cell: &mut Cell,
+    ) -> Result<()> {
+        let mut parentless_invokes: Vec<(&str, InvokeId)> = vec![];
+        for probe_scope in h[cell_scope].scopes(h) {
+            let name = h[probe_scope].name(h);
+            if name.ends_with("_probe") {
+                let out = get_var(h, &h[probe_scope], "out")?;
+                let probe = h[out].signal_ref();
+                let probe_name = parse_probe_name(name)?;
+                match probe_name {
+                    ProbeName::Group { group, component } => {
+                        assert!(
+                            cell.component.is_empty()
+                                || cell.component == component
+                        );
+                        if cell.component.is_empty() {
+                            cell.component = component.to_string();
+                        }
+                        let name = group.to_string();
+                        let invokes = parentless_invokes
+                            .extract_if(.., |(group_name, _)| {
+                                group_name == &name
+                            })
+                            .map(|(_, ii)| ii)
+                            .collect();
+                        let groupid = self.groups.push(Group {
+                            name,
+                            probe,
+                            invokes,
+                        });
+                        cell.groups.push(groupid);
+                    }
+                    ProbeName::InvokePrimitive {
+                        name,
+                        group,
+                        component,
+                    }
+                    | ProbeName::InvokeCell {
+                        name,
+                        group,
+                        component,
+                    } => {
+                        let is_primitive = matches!(
+                            probe_name,
+                            ProbeName::InvokePrimitive { .. }
+                        );
+                        assert!(
+                            cell.component.is_empty()
+                                || cell.component == component
+                        );
+                        if cell.component.is_empty() {
+                            cell.component = component.to_string();
+                        }
+                        let maybe_group = cell
+                            .groups
+                            .iter()
+                            .find(|&&g| self.groups[g].name == group);
+                        // create target cell.
+                        let maybe_target = cell
+                            .instances
+                            .iter()
+                            .find(|&&c| self.cells[c].name == name);
+                        let target = if let Some(&t) = maybe_target {
+                            t
+                        } else {
+                            let scope = get_scope(h, &h[cell_scope], &name)?;
+                            let mut cell_instance = Cell {
+                                name: name.to_string(),
+                                groups: smallvec![],
+                                scope,
+                                is_primitive,
+                                instances: smallvec![],
+                                component: String::new(),
+                            };
+                            self.scan_probes(h, scope, &mut cell_instance)?;
+                            let cell_id = self.cells.push(cell_instance);
+                            cell.instances.push(cell_id);
+                            cell_id
+                        };
+                        let invoke_id = self.invokes.push(Invoke {
+                            name: name.to_string(),
+                            probe,
+                            target,
+                        });
+                        if let Some(&group) = maybe_group {
+                            self.groups[group].invokes.push(invoke_id);
+                        } else {
+                            parentless_invokes.push((group, invoke_id))
+                        }
+                    }
+                }
+            }
+        }
+        assert!(parentless_invokes.is_empty());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_probe_name() {
+        assert_eq!(
+            parse_probe_name("invoke2UG___main_group_probe").unwrap(),
+            ProbeName::Group {
+                group: "invoke2",
+                component: "main"
+            }
+        );
+        assert_eq!(
+            parse_probe_name("mac___invoke2UG___main_cell_probe").unwrap(),
+            ProbeName::InvokeCell {
+                name: "mac",
+                group: "invoke2",
+                component: "main"
+            }
+        );
+        assert_eq!(
+            parse_probe_name("lt0___in_rangeUG___main_primitive_probe")
+                .unwrap(),
+            ProbeName::InvokePrimitive {
+                name: "lt0",
+                group: "in_range",
+                component: "main"
+            }
+        );
+    }
+}

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -1,9 +1,9 @@
 mod design;
 
-use anyhow::{Context, Ok, Result};
+use anyhow::{Context, Ok, Result, anyhow};
 use baa::{BitVecMutOps, BitVecValue};
 use clap::Parser;
-use wellen::*;
+use wellen::{stream::SignalValues, *};
 
 use crate::design::Design;
 
@@ -18,7 +18,7 @@ struct Args {
 }
 
 /// Reads a boolean value from a signal.
-fn read_bool(signal: SignalRef, values: &SignalMap<SignalValue>) -> bool {
+fn read_bool(signal: SignalRef, values: &SignalValues) -> bool {
     let value_ref: SignalValueRef = values.get(&signal).unwrap().into();
     if let SignalValueRef::BitVec(b) = value_ref {
         b.get_bit(0).as_ascii() == '1'
@@ -53,12 +53,12 @@ fn main() -> Result<()> {
     let mut probe_values: Vec<BitVecValue> = vec![];
 
     // populate probe_values on the clock's falling edge
-    wav.stream_time_steps(filter, |time, values| {
-        let c = read_bool(design.clk(), values);
+    wav.stream_time_steps(filter, |time, values, _changed| {
+        let c = read_bool(design.clk(), &values);
         if c && !clock_previous {
             let mut value = BitVecValue::zero(signals.len() as u32);
             for (idx, &signal) in signals.iter().enumerate() {
-                let probe_value = read_bool(signal, values);
+                let probe_value = read_bool(signal, &values);
                 if probe_value {
                     value.set_bit(idx as u32);
                 }
@@ -66,8 +66,14 @@ fn main() -> Result<()> {
             probe_values.push(value);
         }
         clock_previous = c;
+        Ok(())
     })
-    .with_context(|| format!("Failed to stream"))?;
+    .map_err(|e| match e {
+        stream::StreamError::Wellen(wellen_error) => {
+            anyhow!(wellen_error)
+        }
+        stream::StreamError::Callback(e) => e,
+    })?;
     println!("Number of clock ticks: {}", probe_values.len());
 
     // Compute the trace (stacks for each active cycle) from probe_values

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -21,108 +21,6 @@ struct Args {
     filename: String,
 }
 
-#[derive(Debug)]
-struct Vars {
-    clk: SignalRef,
-    main_go: SignalRef,
-    main_done: SignalRef,
-    probes: Vec<VarRef>,
-}
-
-impl Vars {
-    fn get_signal_refs(&self, h: &Hierarchy) -> Vec<SignalRef> {
-        let mut signals: Vec<_> =
-            self.probes.iter().map(|&v| h[v].signal_ref()).collect();
-
-        signals.push(self.clk);
-        signals.push(self.main_go);
-        signals.push(self.main_done);
-
-        signals.sort();
-        signals.dedup();
-
-        signals
-    }
-}
-
-struct ControlTree {
-    main_go_idx: u32,
-    main_done_idx: u32,
-    main_scope: ScopeRef,
-    to_index: FxHashMap<SignalRef, u32>,
-    h: Hierarchy,
-}
-
-impl ControlTree {
-    fn new(
-        main_go_idx: u32,
-        main_done_idx: u32,
-        probe_signals: &[SignalRef],
-        h: Hierarchy,
-    ) -> Result<Self> {
-        let main_scope = h
-            .lookup_scope(&[&"toplevel", &"main"])
-            .with_context(|| format!("Failed to find main scope"))?;
-        let to_index = FxHashMap::from_iter(
-            probe_signals
-                .iter()
-                .enumerate()
-                .map(|(idx, &signal)| (signal, idx as u32)),
-        );
-        Ok(Self {
-            main_go_idx,
-            main_done_idx,
-            main_scope,
-            to_index,
-            h,
-        })
-    }
-
-    fn compute(&self, values: &baa::BitVecValue) -> Result<Vec<Vec<String>>> {
-        let h = &self.h;
-        let mut out = vec![];
-        if (values.is_bit_set(self.main_go_idx)) {
-            let mut stack = vec!["main".to_string()];
-            for scope in h[self.main_scope].scopes(h) {
-                let name = h[scope].name(h);
-                if name.ends_with("_probe") {
-                    let out = get_var(h, &h[scope], "out")?;
-                    let probe_value =
-                        values.is_bit_set(self.to_index[&h[out].signal_ref()]);
-                    if probe_value {
-                        let probe_name = parse_probe_name(name)?;
-                        println!("Probe {probe_name:?} is active.")
-                    }
-                }
-            }
-        }
-        Ok(out)
-    }
-}
-
-fn find_probes(h: &Hierarchy) -> Result<Vars> {
-    let main = h
-        .lookup_scope(&[&"toplevel", &"main"])
-        .with_context(|| format!("Failed to find main scope"))?;
-    let clk = get_var(h, &h[main], "clk")?;
-    let main_go = get_var(h, &h[main], "go")?;
-    let main_done = get_var(h, &h[main], "done")?;
-    let probes: Result<Vec<_>> = h
-        .all_scopes()
-        .filter(|s| s.name(h).ends_with("_probe"))
-        .map(|s| get_var(h, s, "out"))
-        .collect();
-    let probes = probes?;
-
-    println!("Found {} probes", probes.len());
-    Ok(Vars {
-        clk: h[clk].signal_ref(),
-        main_go: h[main_go].signal_ref(),
-        main_done: h[main_done].signal_ref(),
-        probes,
-    })
-}
-
 fn read_bool(signal: SignalRef, values: &SignalMap<SignalValue>) -> bool {
     let value_ref: SignalValueRef = values.get(&signal).unwrap().into();
     if let SignalValueRef::BitVec(b) = value_ref {
@@ -145,39 +43,23 @@ fn main() -> Result<()> {
 
     let design = Design::new(wav.hierarchy())?;
 
-    let vars = find_probes(wav.hierarchy())?;
-    let signals = vars.get_signal_refs(wav.hierarchy());
+    let signals = design.get_signals();
 
     let filter = wellen::stream::Filter::include_signals(&signals);
 
     let mut clock_previous = true;
-    let probe_signals: Vec<_> = vars
-        .probes
-        .iter()
-        .map(|&v| wav.hierarchy()[v].signal_ref())
-        .collect();
 
-    let main_go_idx = probe_signals.len() as u32;
-    let main_done_idx = probe_signals.len() as u32 + 1;
     let mut probe_values: Vec<_> = vec![];
 
     wav.stream_time_steps(filter, |time, values| {
-        let c = read_bool(vars.clk, values);
+        let c = read_bool(design.clk(), values);
         if c && !clock_previous {
-            let mut value =
-                baa::BitVecValue::zero(probe_signals.len() as u32 + 2);
-            for (idx, &signal) in probe_signals.iter().enumerate() {
+            let mut value = baa::BitVecValue::zero(signals.len() as u32);
+            for (idx, &signal) in signals.iter().enumerate() {
                 let probe_value = read_bool(signal, values);
                 if probe_value {
                     value.set_bit(idx as u32);
                 }
-            }
-            // accounting for main_go and main_done
-            if read_bool(vars.main_go, values) {
-                value.set_bit(main_go_idx);
-            }
-            if read_bool(vars.main_done, values) {
-                value.set_bit(main_done_idx);
             }
             probe_values.push(value);
         }
@@ -187,14 +69,9 @@ fn main() -> Result<()> {
 
     println!("probe value len: {}", probe_values.len());
 
-    let tree = ControlTree::new(
-        main_go_idx,
-        main_done_idx,
-        &probe_signals,
-        wav.hierarchy().clone(),
-    )?;
     for (idx, value) in probe_values.iter().enumerate().take(15) {
-        println!("{idx} {:?}", tree.compute(value));
+        println!("{idx}");
+        design.compute(value)?;
     }
 
     Ok(())

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -69,9 +69,16 @@ fn main() -> Result<()> {
 
     println!("probe value len: {}", probe_values.len());
 
+    let mut cycle_count = -1;
     for (idx, value) in probe_values.iter().enumerate().take(15) {
-        println!("{idx}");
-        design.compute(value)?;
+        let stacks = design.compute(value)?;
+        if !stacks.is_empty() {
+            cycle_count += 1;
+            println!("{cycle_count}");
+            for stack in stacks {
+                println!("{stack:?}");
+            }
+        }
     }
 
     Ok(())

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -19,7 +19,7 @@ struct Args {
 
 /// Reads a boolean value from a signal.
 fn read_bool(signal: SignalRef, values: &SignalValues) -> bool {
-    let value_ref: SignalValueRef = values.get(&signal).unwrap().into();
+    let value_ref: SignalValueRef = values.get(&signal).unwrap();
     if let SignalValueRef::BitVec(b) = value_ref {
         b.get_bit(0).as_ascii() == '1'
     } else {
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
     let mut probe_values: Vec<BitVecValue> = vec![];
 
     // populate probe_values on the clock's falling edge
-    wav.stream_time_steps(filter, |time, values, _changed| {
+    wav.stream_time_steps(filter, |_time, values, _changed| {
         let c = read_bool(design.clk(), &values);
         if c && !clock_previous {
             let mut value = BitVecValue::zero(signals.len() as u32);
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
 
     // Compute the trace (stacks for each active cycle) from probe_values
     let mut cycle_count = -1;
-    for (_, value) in probe_values.iter().enumerate() {
+    for value in probe_values.iter() {
         // .take(15) // for debugging
         let stacks = design.compute_cycle_trace(value)?;
         if !stacks.is_empty() {

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -1,12 +1,8 @@
 mod design;
 
-use design::{get_var, parse_probe_name};
-
 use anyhow::{Context, Ok, Result};
-use baa::BitVecMutOps;
-use baa::BitVecOps;
+use baa::{BitVecMutOps, BitVecValue};
 use clap::Parser;
-use rustc_hash::FxHashMap;
 use wellen::*;
 
 use crate::design::Design;
@@ -41,20 +37,25 @@ fn main() -> Result<()> {
     let mut wav = wellen::stream::read_from_file(&args.filename, &opts)
         .with_context(|| format!("Failed to load {}", args.filename))?;
 
+    // static tree
     let design = Design::new(wav.hierarchy())?;
 
+    // all probe signals we would need to track
     let signals = design.get_signals();
 
     let filter = wellen::stream::Filter::include_signals(&signals);
 
     let mut clock_previous = true;
 
-    let mut probe_values: Vec<_> = vec![];
+    // One bit vector for each cycle. Each index in the BitVecValue corresponds to a probe.
+    // If it is active, the index will contain 1.
+    let mut probe_values: Vec<BitVecValue> = vec![];
 
+    // populate probe_values on the clock's falling edge
     wav.stream_time_steps(filter, |time, values| {
         let c = read_bool(design.clk(), values);
         if c && !clock_previous {
-            let mut value = baa::BitVecValue::zero(signals.len() as u32);
+            let mut value = BitVecValue::zero(signals.len() as u32);
             for (idx, &signal) in signals.iter().enumerate() {
                 let probe_value = read_bool(signal, values);
                 if probe_value {
@@ -66,17 +67,19 @@ fn main() -> Result<()> {
         clock_previous = c;
     })
     .with_context(|| format!("Failed to stream"))?;
+    println!("Number of clock ticks: {}", probe_values.len());
 
-    println!("probe value len: {}", probe_values.len());
-
+    // Compute the trace (stacks for each active cycle) from probe_values
     let mut cycle_count = -1;
-    for (idx, value) in probe_values.iter().enumerate().take(15) {
+    for (_, value) in probe_values.iter().enumerate() {
+        // .take(15) // for debugging
         let stacks = design.compute(value)?;
         if !stacks.is_empty() {
             cycle_count += 1;
             println!("{cycle_count}");
             for stack in stacks {
-                println!("{stack:?}");
+                let stack_str = stack.join(", ");
+                println!("	[{stack_str}]");
             }
         }
     }

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -1,6 +1,6 @@
-mod hierarchy;
+mod design;
 
-use hierarchy::{get_var, parse_probe_name};
+use design::{get_var, parse_probe_name};
 
 use anyhow::{Context, Ok, Result};
 use baa::BitVecMutOps;
@@ -9,7 +9,7 @@ use clap::Parser;
 use rustc_hash::FxHashMap;
 use wellen::*;
 
-use crate::hierarchy::Design;
+use crate::design::Design;
 
 #[derive(Parser, Debug)]
 #[command(name = "petal")]

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -1,0 +1,201 @@
+mod hierarchy;
+
+use hierarchy::{get_var, parse_probe_name};
+
+use anyhow::{Context, Ok, Result};
+use baa::BitVecMutOps;
+use baa::BitVecOps;
+use clap::Parser;
+use rustc_hash::FxHashMap;
+use wellen::*;
+
+use crate::hierarchy::Design;
+
+#[derive(Parser, Debug)]
+#[command(name = "petal")]
+#[command(author = "Ayaka Yorihiro <ayaka@cs.cornell.edu>")]
+#[command(version)]
+#[command(about = "Calyx profiler.", long_about = None)]
+struct Args {
+    #[arg(value_name = "WAV", index = 1)]
+    filename: String,
+}
+
+#[derive(Debug)]
+struct Vars {
+    clk: SignalRef,
+    main_go: SignalRef,
+    main_done: SignalRef,
+    probes: Vec<VarRef>,
+}
+
+impl Vars {
+    fn get_signal_refs(&self, h: &Hierarchy) -> Vec<SignalRef> {
+        let mut signals: Vec<_> =
+            self.probes.iter().map(|&v| h[v].signal_ref()).collect();
+
+        signals.push(self.clk);
+        signals.push(self.main_go);
+        signals.push(self.main_done);
+
+        signals.sort();
+        signals.dedup();
+
+        signals
+    }
+}
+
+struct ControlTree {
+    main_go_idx: u32,
+    main_done_idx: u32,
+    main_scope: ScopeRef,
+    to_index: FxHashMap<SignalRef, u32>,
+    h: Hierarchy,
+}
+
+impl ControlTree {
+    fn new(
+        main_go_idx: u32,
+        main_done_idx: u32,
+        probe_signals: &[SignalRef],
+        h: Hierarchy,
+    ) -> Result<Self> {
+        let main_scope = h
+            .lookup_scope(&[&"toplevel", &"main"])
+            .with_context(|| format!("Failed to find main scope"))?;
+        let to_index = FxHashMap::from_iter(
+            probe_signals
+                .iter()
+                .enumerate()
+                .map(|(idx, &signal)| (signal, idx as u32)),
+        );
+        Ok(Self {
+            main_go_idx,
+            main_done_idx,
+            main_scope,
+            to_index,
+            h,
+        })
+    }
+
+    fn compute(&self, values: &baa::BitVecValue) -> Result<Vec<Vec<String>>> {
+        let h = &self.h;
+        let mut out = vec![];
+        if (values.is_bit_set(self.main_go_idx)) {
+            let mut stack = vec!["main".to_string()];
+            for scope in h[self.main_scope].scopes(h) {
+                let name = h[scope].name(h);
+                if name.ends_with("_probe") {
+                    let out = get_var(h, &h[scope], "out")?;
+                    let probe_value =
+                        values.is_bit_set(self.to_index[&h[out].signal_ref()]);
+                    if probe_value {
+                        let probe_name = parse_probe_name(name)?;
+                        println!("Probe {probe_name:?} is active.")
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+fn find_probes(h: &Hierarchy) -> Result<Vars> {
+    let main = h
+        .lookup_scope(&[&"toplevel", &"main"])
+        .with_context(|| format!("Failed to find main scope"))?;
+    let clk = get_var(h, &h[main], "clk")?;
+    let main_go = get_var(h, &h[main], "go")?;
+    let main_done = get_var(h, &h[main], "done")?;
+    let probes: Result<Vec<_>> = h
+        .all_scopes()
+        .filter(|s| s.name(h).ends_with("_probe"))
+        .map(|s| get_var(h, s, "out"))
+        .collect();
+    let probes = probes?;
+
+    println!("Found {} probes", probes.len());
+    Ok(Vars {
+        clk: h[clk].signal_ref(),
+        main_go: h[main_go].signal_ref(),
+        main_done: h[main_done].signal_ref(),
+        probes,
+    })
+}
+
+fn read_bool(signal: SignalRef, values: &SignalMap<SignalValue>) -> bool {
+    let value_ref: SignalValueRef = values.get(&signal).unwrap().into();
+    if let SignalValueRef::BitVec(b) = value_ref {
+        b.get_bit(0).as_ascii() == '1'
+    } else {
+        panic!("Clock needs to be a bitvector!");
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let opts = LoadOptions {
+        multi_thread: true,
+        remove_scopes_with_empty_name: false,
+    };
+
+    let mut wav = wellen::stream::read_from_file(&args.filename, &opts)
+        .with_context(|| format!("Failed to load {}", args.filename))?;
+
+    let design = Design::new(wav.hierarchy())?;
+
+    let vars = find_probes(wav.hierarchy())?;
+    let signals = vars.get_signal_refs(wav.hierarchy());
+
+    let filter = wellen::stream::Filter::include_signals(&signals);
+
+    let mut clock_previous = true;
+    let probe_signals: Vec<_> = vars
+        .probes
+        .iter()
+        .map(|&v| wav.hierarchy()[v].signal_ref())
+        .collect();
+
+    let main_go_idx = probe_signals.len() as u32;
+    let main_done_idx = probe_signals.len() as u32 + 1;
+    let mut probe_values: Vec<_> = vec![];
+
+    wav.stream_time_steps(filter, |time, values| {
+        let c = read_bool(vars.clk, values);
+        if c && !clock_previous {
+            let mut value =
+                baa::BitVecValue::zero(probe_signals.len() as u32 + 2);
+            for (idx, &signal) in probe_signals.iter().enumerate() {
+                let probe_value = read_bool(signal, values);
+                if probe_value {
+                    value.set_bit(idx as u32);
+                }
+            }
+            // accounting for main_go and main_done
+            if read_bool(vars.main_go, values) {
+                value.set_bit(main_go_idx);
+            }
+            if read_bool(vars.main_done, values) {
+                value.set_bit(main_done_idx);
+            }
+            probe_values.push(value);
+        }
+        clock_previous = c;
+    })
+    .with_context(|| format!("Failed to stream"))?;
+
+    println!("probe value len: {}", probe_values.len());
+
+    let tree = ControlTree::new(
+        main_go_idx,
+        main_done_idx,
+        &probe_signals,
+        wav.hierarchy().clone(),
+    )?;
+    for (idx, value) in probe_values.iter().enumerate().take(15) {
+        println!("{idx} {:?}", tree.compute(value));
+    }
+
+    Ok(())
+}

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -17,12 +17,13 @@ struct Args {
     filename: String,
 }
 
+/// Reads a boolean value from a signal.
 fn read_bool(signal: SignalRef, values: &SignalMap<SignalValue>) -> bool {
     let value_ref: SignalValueRef = values.get(&signal).unwrap().into();
     if let SignalValueRef::BitVec(b) = value_ref {
         b.get_bit(0).as_ascii() == '1'
     } else {
-        panic!("Clock needs to be a bitvector!");
+        panic!("Signal needs to be a bitvector!");
     }
 }
 
@@ -73,7 +74,7 @@ fn main() -> Result<()> {
     let mut cycle_count = -1;
     for (_, value) in probe_values.iter().enumerate() {
         // .take(15) // for debugging
-        let stacks = design.compute(value)?;
+        let stacks = design.compute_cycle_trace(value)?;
         if !stacks.is_empty() {
             cycle_count += 1;
             println!("{cycle_count}");

--- a/tools/petal/test/language-tutorial-iterate.expect
+++ b/tools/petal/test/language-tutorial-iterate.expect
@@ -1,0 +1,99 @@
+Number of clock ticks: 41
+0
+	[main, init, counter (primitive)]
+1
+	[main]
+2
+	[main, cond, lt (primitive)]
+3
+	[main]
+4
+	[main, incr, add2 (primitive)]
+	[main, incr, counter (primitive)]
+	[main, read, val (primitive)]
+5
+	[main, upd, add (primitive)]
+	[main, upd, val (primitive)]
+6
+	[main, write, mem (primitive)]
+7
+	[main, cond, lt (primitive)]
+8
+	[main, incr, add2 (primitive)]
+	[main, incr, counter (primitive)]
+	[main, read, val (primitive)]
+9
+	[main, upd, add (primitive)]
+	[main, upd, val (primitive)]
+10
+	[main, write, mem (primitive)]
+11
+	[main, cond, lt (primitive)]
+12
+	[main, incr, add2 (primitive)]
+	[main, incr, counter (primitive)]
+	[main, read, val (primitive)]
+13
+	[main, upd, add (primitive)]
+	[main, upd, val (primitive)]
+14
+	[main, write, mem (primitive)]
+15
+	[main, cond, lt (primitive)]
+16
+	[main, incr, add2 (primitive)]
+	[main, incr, counter (primitive)]
+	[main, read, val (primitive)]
+17
+	[main, upd, add (primitive)]
+	[main, upd, val (primitive)]
+18
+	[main, write, mem (primitive)]
+19
+	[main, cond, lt (primitive)]
+20
+	[main, incr, add2 (primitive)]
+	[main, incr, counter (primitive)]
+	[main, read, val (primitive)]
+21
+	[main, upd, add (primitive)]
+	[main, upd, val (primitive)]
+22
+	[main, write, mem (primitive)]
+23
+	[main, cond, lt (primitive)]
+24
+	[main, incr, add2 (primitive)]
+	[main, incr, counter (primitive)]
+	[main, read, val (primitive)]
+25
+	[main, upd, add (primitive)]
+	[main, upd, val (primitive)]
+26
+	[main, write, mem (primitive)]
+27
+	[main, cond, lt (primitive)]
+28
+	[main, incr, add2 (primitive)]
+	[main, incr, counter (primitive)]
+	[main, read, val (primitive)]
+29
+	[main, upd, add (primitive)]
+	[main, upd, val (primitive)]
+30
+	[main, write, mem (primitive)]
+31
+	[main, cond, lt (primitive)]
+32
+	[main, incr, add2 (primitive)]
+	[main, incr, counter (primitive)]
+	[main, read, val (primitive)]
+33
+	[main, upd, add (primitive)]
+	[main, upd, val (primitive)]
+34
+	[main, write, mem (primitive)]
+35
+	[main, cond, lt (primitive)]
+36
+	[main]

--- a/tools/petal/test/language-tutorial-iterate.futil
+++ b/tools/petal/test/language-tutorial-iterate.futil
@@ -1,0 +1,83 @@
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+
+component main() -> () {
+  cells {
+    @external(1) mem = comb_mem_d1(32, 1, 1);
+    val = std_reg(32);
+    add = std_add(32);
+
+    // ANCHOR: new_cells
+    counter = std_reg(32);
+    add2 = std_add(32);
+    lt = std_lt(32);
+    // ANCHOR_END: new_cells
+  }
+
+  wires {
+    group read {
+      mem.addr0 = 1'b0;
+      val.in = mem.read_data;
+      val.write_en = 1'b1;
+      read[done] = val.done;
+    }
+
+    group upd {
+      add.left = val.out;
+      add.right = 32'd4;
+      val.in = add.out;
+      val.write_en = 1'b1;
+      upd[done] = val.done;
+    }
+
+    group write {
+      mem.addr0 = 1'b0;
+      mem.write_en = 1'b1;
+      mem.write_data = val.out;
+      write[done] = mem.done;
+    }
+
+    // ANCHOR: init
+    group init {
+      counter.in = 32'd0;
+      counter.write_en = 1'b1;
+      init[done] = counter.done;
+    }
+    // ANCHOR_END: init
+
+    // ANCHOR: incr
+    group incr {
+      add2.left = counter.out;
+      add2.right = 32'd1;
+      counter.in = add2.out;
+      counter.write_en = 1'b1;
+      incr[done] = counter.done;
+    }
+    // ANCHOR_END: incr
+
+    // ANCHOR: cond
+    comb group cond {
+      lt.left = counter.out;
+      lt.right = 32'd8;
+    }
+    // ANCHOR_END: cond
+  }
+
+  // ANCHOR: control
+  control {
+    seq {
+      init;
+      while lt.out with cond {
+        par {
+          seq {
+            read;
+            upd;
+            write;
+          }
+          incr;
+        }
+      }
+    }
+  }
+  // ANCHOR_END: control
+}

--- a/tools/petal/test/language-tutorial-iterate.futil.data
+++ b/tools/petal/test/language-tutorial-iterate.futil.data
@@ -1,0 +1,10 @@
+{
+  "mem": {
+    "data": [10],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": false,
+      "width": 32
+    }
+  }
+}

--- a/tools/petal/test/pipelined-mac.expect
+++ b/tools/petal/test/pipelined-mac.expect
@@ -1,0 +1,245 @@
+Number of clock ticks: 96
+0
+	[main, init_all, idx0 (primitive)]
+1
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+2
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac0, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+3
+	[main, invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+4
+	[main, invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+5
+	[main, invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+6
+	[main, invoke_mac0, mac [pipelined_mac], stage1, pipe1 (primitive)]
+7
+	[main, invoke_mac0, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, invoke_mac0, mac [pipelined_mac], unset_out_valid, out_valid (primitive)]
+8
+	[main]
+9
+	[main, in_range, lt0 (primitive)]
+10
+	[main]
+11
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+12
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+13
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+14
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+15
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+16
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+17
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+18
+	[main, in_range, lt0 (primitive)]
+19
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+20
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+21
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+22
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+23
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+24
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+25
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+26
+	[main, in_range, lt0 (primitive)]
+27
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+28
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+29
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+30
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+31
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+32
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+33
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+34
+	[main, in_range, lt0 (primitive)]
+35
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+36
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+37
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+38
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+39
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+40
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+41
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+42
+	[main, in_range, lt0 (primitive)]
+43
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+44
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+45
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+46
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+47
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+48
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+49
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+50
+	[main, in_range, lt0 (primitive)]
+51
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+52
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+53
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+54
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+55
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+56
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+57
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+58
+	[main, in_range, lt0 (primitive)]
+59
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+60
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+61
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+62
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+63
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+64
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+65
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+66
+	[main, in_range, lt0 (primitive)]
+67
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+68
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+69
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+70
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+71
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+72
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+73
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+74
+	[main, in_range, lt0 (primitive)]
+75
+	[main, store_a, read_a (primitive)]
+	[main, store_b, read_b (primitive)]
+76
+	[main, incr_idx, add0 (primitive)]
+	[main, incr_idx, idx0 (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+77
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+78
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+79
+	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+80
+	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+81
+	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+82
+	[main, in_range, lt0 (primitive)]
+83
+	[main]
+84
+	[main, invoke_mac2, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+85
+	[main, invoke_mac2, mac [pipelined_mac], stage2, add (primitive)]
+	[main, invoke_mac2, mac [pipelined_mac], stage2, pipe2 (primitive)]
+86
+	[main, invoke_mac2, mac [pipelined_mac]]
+87
+	[main, invoke_mac2, mac [pipelined_mac]]
+88
+	[main, invoke_mac2, mac [pipelined_mac]]
+89
+	[main, invoke_mac2, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, invoke_mac2, mac [pipelined_mac], unset_stage2_valid, stage2_valid (primitive)]
+90
+	[main, save_out, out (primitive)]
+91
+	[main]

--- a/tools/petal/test/pipelined-mac.futil
+++ b/tools/petal/test/pipelined-mac.futil
@@ -1,0 +1,183 @@
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+import "primitives/binary_operators.futil";
+
+component pipelined_mac(
+  data_valid: 1,
+  a: 32,
+  b: 32,
+  c: 32
+) -> (
+  out: 32,
+  output_valid: 1
+) {
+  cells {
+    mult_pipe = std_mult_pipe(32);
+    add = std_add(32);
+
+    // Pipeline register between stage 1 & 2
+    pipe1 = std_reg(32);
+    // Pipeline register after stage 2
+    pipe2 = std_reg(32);
+
+    stage2_valid = std_reg(1); // Stage 2 should run this execution
+    out_valid = std_reg(1);    // Output is valid
+    data_valid_reg = std_reg(1); // Stores value of data_valid
+  }
+  wires {
+    group stage1<"static"=4> {
+      mult_pipe.left = a;
+      mult_pipe.right = b;
+      pipe1.in = mult_pipe.out;
+      pipe1.write_en = mult_pipe.done;
+      mult_pipe.go = !mult_pipe.done ? 1'd1;
+      stage1[done] = pipe1.done;
+    }
+    group stage2 {
+      add.left = pipe1.out;
+      add.right = c;
+      pipe2.write_en = 1'd1;
+      pipe2.in = add.out;
+      stage2[done] = pipe2.done;
+    }
+    group set_stage2_valid {
+      stage2_valid.in = 1'd1;
+      stage2_valid.write_en = 1'd1;
+      set_stage2_valid[done] = stage2_valid.done;
+    }
+    group unset_stage2_valid {
+      stage2_valid.in = 1'd0;
+      stage2_valid.write_en = 1'd1;
+      unset_stage2_valid[done] = stage2_valid.done;
+    }
+
+    group set_out_valid {
+      out_valid.in = 1'd1;
+      out_valid.write_en = 1'd1;
+      set_out_valid[done] = out_valid.done;
+    }
+    group unset_out_valid {
+      out_valid.in = 1'd0;
+      out_valid.write_en = 1'd1;
+      unset_out_valid[done] = out_valid.done;
+    }
+    group write_data_valid {
+      data_valid_reg.write_en = 1'd1;
+      data_valid_reg.in = data_valid;
+      write_data_valid[done] = data_valid_reg.done;
+    }
+
+    output_valid = out_valid.out;
+    out = pipe2.out;
+  }
+  control {
+    seq {
+      write_data_valid;
+      // Execute all stages in parallel
+      par {
+        if data_valid_reg.out { stage1; }
+        if stage2_valid.out { stage2; }
+      }
+      // Configure valid signals for next invoke
+      par {
+        if data_valid_reg.out {
+          set_stage2_valid;
+        } else {
+          unset_stage2_valid;
+        }
+        if stage2_valid.out {
+          set_out_valid;
+        } else {
+          unset_out_valid;
+        }
+      }
+    }
+  }
+}
+
+component main() -> () {
+  cells {
+    // Input memories
+    @external a = comb_mem_d1(32, 10, 4);
+    @external b = comb_mem_d1(32, 10, 4);
+
+    // Output memory: Expected output 31178
+    @external out = comb_mem_d1(32, 1, 1);
+
+    // Registers to save value at current memory index
+    read_a = std_reg(32);
+    read_b = std_reg(32);
+    read_c = std_reg(32);
+
+    // Index into memories `a` & `b`.
+    idx0 = std_reg(4);
+    add0 = std_add(4);
+    lt0 = std_lt(4);
+
+    mac = pipelined_mac();
+  }
+  wires {
+    group init_all {
+      idx0.in = 4'd0;
+      idx0.write_en = 1'd1;
+      init_all[done] = idx0.done;
+    }
+    group store_a {
+      a.addr0 = idx0.out;
+      read_a.write_en = 1'd1;
+      read_a.in = a.read_data;
+      store_a[done] = read_a.done;
+    }
+    group store_b {
+      b.addr0 = idx0.out;
+      read_b.write_en = 1'd1;
+      read_b.in = b.read_data;
+      store_b[done] = read_b.done;
+    }
+    group incr_idx {
+      idx0.in = add0.out;
+      idx0.write_en = 1'd1;
+      add0.left = 4'd1;
+      add0.right = idx0.out;
+      incr_idx[done] = idx0.done;
+    }
+    group save_out {
+      out.addr0 = 1'd0;
+      out.write_en = 1'd1;
+      out.write_data = mac.out;
+      save_out[done] = out.done;
+    }
+    comb group in_range {
+      lt0.left = idx0.out;
+      lt0.right = 4'd10;
+    }
+  }
+  control {
+    seq {
+      init_all;
+      // Pipeline initialization: when idx0 == 0.
+      // Perform the first multiplication w/o accumulate
+      par { store_a; store_b; }
+      invoke mac(data_valid = 1'd1, a = read_a.out, b = read_b.out)();
+      incr_idx;
+      // Pipeline steady-state: when idx0 < 10.
+      // Perform i+1 th multiply & i th accumulate
+      while lt0.out with in_range {
+        seq {
+          par { store_a; store_b; }
+          invoke mac(
+            data_valid = 1'd1,
+            a = read_a.out,
+            b = read_b.out,
+            c = mac.out
+          )();
+          incr_idx;
+        }
+      }
+      // Pipeline flushing: when idx0 == 10.
+      // Perform the final accumulate
+      invoke mac(c = mac.out)();
+      save_out;
+    }
+  }
+}

--- a/tools/petal/test/pipelined-mac.futil.data
+++ b/tools/petal/test/pipelined-mac.futil.data
@@ -1,0 +1,26 @@
+{
+  "a": {
+    "data": [77, 15,  3, 22, 81, 80, 43, 70, 47, 69],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": false,
+      "width": 32
+    }
+  },
+  "b": {
+    "data": [75, 83, 33, 93, 30, 94, 43, 11, 60, 96],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": false,
+      "width": 32
+    }
+  },
+  "out": {
+    "data": [0],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": false,
+      "width": 32
+    }
+  }
+}

--- a/tools/petal/test/structural-enable-cond.expect
+++ b/tools/petal/test/structural-enable-cond.expect
@@ -1,0 +1,3 @@
+Number of clock ticks: 5
+0
+	[main, wr_b, wr_a, a (primitive)]

--- a/tools/petal/test/structural-enable-cond.futil
+++ b/tools/petal/test/structural-enable-cond.futil
@@ -1,5 +1,3 @@
-// -p profiler-instrumentation
-
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
 

--- a/tools/petal/test/structural-enable-cond.futil
+++ b/tools/petal/test/structural-enable-cond.futil
@@ -1,0 +1,29 @@
+// -p profiler-instrumentation
+
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+
+component main() -> () {
+  cells {
+    @external(1) a = comb_mem_d1(32, 1, 1);
+    lt = std_lt(32);
+  }
+
+  wires {
+   group wr_a {
+      a.addr0 = 1'b0;
+      a.write_en = 1'b1;
+      a.write_data = 32'd1;
+      wr_a[done] = a.done;
+    }
+
+    group wr_b {
+    wr_a[go] = 1'b1;
+    wr_b[done] = wr_a[done];
+    }
+  }
+
+  control {
+      wr_b;
+  }
+}

--- a/tools/petal/test/structural-enable-cond.futil.data
+++ b/tools/petal/test/structural-enable-cond.futil.data
@@ -1,0 +1,12 @@
+{
+  "a": {
+    "data": [
+      0
+    ],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": true,
+      "width": 32
+    }
+  }
+}

--- a/tools/profiler/profiler/classes/stack_element.py
+++ b/tools/profiler/profiler/classes/stack_element.py
@@ -57,6 +57,12 @@ class StackElement:
         else:
             return self.internal_name
 
+    def __le__(self, other):
+        return self.__repr__() <= other.__repr__()
+
+    def __lt__(self, other):
+        return self.__repr__() < other.__repr__()
+
     def __repr__(self):
         match self.element_type:
             case StackElementType.GROUP:

--- a/tools/profiler/profiler/classes/tracedata.py
+++ b/tools/profiler/profiler/classes/tracedata.py
@@ -55,7 +55,7 @@ class CycleTrace:
 
     def __repr__(self):
         out = ""
-        out = "\n".join(map(lambda x: f"\t{x}", self.stacks))
+        out = "\n".join(map(lambda x: f"\t{x}", sorted(self.stacks)))
         return out
 
     def __init__(self, stacks_this_cycle: list[list[StackElement]] | None = None):
@@ -347,8 +347,8 @@ class PTrace:
         self.trace.append(cycle_trace)
 
     def string_repr(self, mode: FlameMapMode) -> list[set[str]]:
-        return list(
-            map(lambda cycletrace: cycletrace.get_stack_str_set(mode), self.trace)
+        return sorted(
+            list(map(lambda cycletrace: cycletrace.get_stack_str_set(mode), self.trace))
         )
 
     def __getitem__(self, index):


### PR DESCRIPTION
This PR contains some initial code for a Rust re-implementation of the Calyx profiler (Petal). We use @ekiwi 's [Wellen](https://github.com/ekiwi/wellen) library for VCD parsing! Another key change is that we build up a static call tree from the set of available probes, and active probes for every cycle are used to construct the dynamic call tree.

The crate lives in `tools/petal`. To run, provide the instrumented VCD file provided from running the `fud2` profiler workflow:
ex) From the Calyx base directory
```
fud2 tests/correctness/pipelined-mac.futil -o svgs/pipelined-mac.svg -s sim.data=tests/correctness/pipelined-mac.futil.data  --through profiler --dir fud2-pipelined-mac
cd tools/petal
cargo run -- ../../fud2-pipelined-mac/instrumented.vcd
```

Some initial tests are in `tools/petal/test`. They can be run via `runt`: `runt -i "Petal"`. The expected output is equivalent to the original Petal implementation's intermediate output (minus control nodes).

## Next steps
For a real MVP, we will need support for:
- Control nodes
- Visualizations
- a fud2 op
Once we get control nodes, we can start some initial performance comparisons between Python Petal and Rusted Petal :)