### PR TITLE
[Profiler] Rusted Petal: flame graphs with control and shared cells 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,8 @@ dependencies = [
  "clap 4.6.1",
  "cranelift-entity 0.128.4",
  "rustc-hash",
+ "serde",
+ "serde_json",
  "smallvec",
  "wellen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "baa",
  "clap 4.6.1",
  "cranelift-entity 0.128.4",
+ "log",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/runt.toml
+++ b/runt.toml
@@ -730,7 +730,7 @@ svg=${petal_test_dir}/${basename}.svg && \
 petal_test_dir=${dirname}/${basename} && \
 fud2 {} -o ${svg} --through profiler -s sim.data={}.data --dir ${petal_test_dir} 2> /dev/null
 
-target/debug/petal ${petal_test_dir}/instrumented.vcd ${petal_test_dir}/fsm.json ${petal_test_dir}/path-descriptors.json ${petal_test_dir}/ctrl-pos.json 2> /dev/null
+target/debug/petal ${petal_test_dir}/instrumented.vcd ${petal_test_dir}/fsm.json ${petal_test_dir}/path-descriptors.json ${petal_test_dir}/ctrl-pos.json ${petal_test_dir}/shared-cells.json 2> /dev/null
 
 rm -rf ${petal_test_dir}
 """

--- a/runt.toml
+++ b/runt.toml
@@ -728,9 +728,13 @@ dirname=$(dirname {}) && \
 basename=$(basename {} .futil) && \
 svg=${petal_test_dir}/${basename}.svg && \
 petal_test_dir=${dirname}/${basename} && \
+flame=${petal_test_dir}/flat-flame.folded && \
 fud2 {} -o ${svg} --through profiler -s sim.data={}.data --dir ${petal_test_dir} 2> /dev/null
 
-target/debug/petal ${petal_test_dir}/instrumented.vcd ${petal_test_dir}/fsm.json ${petal_test_dir}/path-descriptors.json ${petal_test_dir}/ctrl-pos.json ${petal_test_dir}/shared-cells.json 2> /dev/null
+target/debug/petal ${petal_test_dir}/instrumented.vcd ${petal_test_dir}/fsm.json ${petal_test_dir}/path-descriptors.json ${petal_test_dir}/ctrl-pos.json ${petal_test_dir}/shared-cells.json --flat-flame-out ${flame} 2> /dev/null
+
+echo ====FLAT FLAME OUTPUT==== 
+cat ${flame}
 
 rm -rf ${petal_test_dir}
 """

--- a/runt.toml
+++ b/runt.toml
@@ -730,6 +730,7 @@ svg=${petal_test_dir}/${basename}.svg && \
 petal_test_dir=${dirname}/${basename} && \
 fud2 {} -o ${svg} --through profiler -s sim.data={}.data --dir ${petal_test_dir} 2> /dev/null
 
-target/debug/petal ${petal_test_dir}/instrumented.vcd && \
+target/debug/petal ${petal_test_dir}/instrumented.vcd ${petal_test_dir}/fsm.json ${petal_test_dir}/path-descriptors.json ${petal_test_dir}/ctrl-pos.json 2> /dev/null
+
 rm -rf ${petal_test_dir}
 """

--- a/tools/petal/Cargo.toml
+++ b/tools/petal/Cargo.toml
@@ -20,3 +20,5 @@ baa.workspace = true
 rustc-hash = "2.1.2"
 cranelift-entity = "0.128.4"
 smallvec.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/tools/petal/Cargo.toml
+++ b/tools/petal/Cargo.toml
@@ -22,3 +22,4 @@ cranelift-entity = "0.128.4"
 smallvec.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+log.workspace = true

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -89,6 +89,7 @@ struct FSMStateInfo {
 }
 
 /// Represents the registers that do the bookkeeping for a control group
+/// NOTE: Will be necessary for the timeline view, but not for the flame graph.
 // #[derive(Debug)]
 // enum ControlRegister {
 //     FSM(String),
@@ -96,21 +97,27 @@ struct FSMStateInfo {
 // }
 
 #[derive(Debug, Clone)]
+/// Information for the control group obtained from the TDCC compiler pass.
+/// NOTE: More will be added for the timeline view.
 pub struct TdccInfo {
     pub name: String,
 }
 
 #[derive(Debug)]
+/// Represents all statically obtained information (from compiler passes & external tools)
+/// about control nodes (ex. seq, par) and the control groups (ex. tdcc*) used to manage them.
 pub struct ControlInfo {
-    // Note: If the original program was written in an ADL, there would be multiple entries
-    // for the same TDCC group (for each position from the ADL)
-    // We also use a vector because multiple control nodes may map to the same position in the ADL
+    /// Obtained from the TDCC pass that converts control nodes to control groups.
+    /// Note: If the original program was written in an ADL, there would be multiple entries
+    /// for the same TDCC group (for each position from the ADL)
+    /// We also use a vector because multiple control nodes may map to the same position in the ADL
     tdcc_map: FxHashMap<u32, Vec<TdccInfo>>,
 
-    // names for pretty printing
+    /// names for pretty printing (from control-pos file)
     pretty_map: FxHashMap<u32, String>,
 
-    // info taken straight from the path-descriptors file
+    /// info taken straight from the path-descriptors file (for computing parent-child relationships
+    /// between control groups & groups.
     pd: BTreeMap<String, PathDescriptorInfo>,
 }
 
@@ -142,7 +149,7 @@ impl ControlInfo {
         let mut tdcc_map = FxHashMap::default();
 
         // need to process pos_file first because it gives us the Calyx positions of all control nodes.
-        eprintln!("Parsing {}", pos_filename);
+        log::debug!("Parsing {}", pos_filename);
         let pos_file = File::open(pos_filename)?;
         let pos: HashMap<String, Vec<ControlCalyxPosInfo>> =
             serde_json::from_reader(BufReader::new(pos_file))?;
@@ -153,7 +160,7 @@ impl ControlInfo {
             }
         }
 
-        eprintln!("Parsing {}", tdcc_filename);
+        log::debug!("Parsing {}", tdcc_filename);
         let tdcc_file = File::open(tdcc_filename)?;
         let tdcc_profiling_info: HashSet<ProfilingInfo> =
             serde_json::from_reader(BufReader::new(tdcc_file))?;
@@ -176,7 +183,7 @@ impl ControlInfo {
             }
         }
 
-        eprintln!("Parsing {}", pd_filename);
+        log::debug!("Parsing {}", pd_filename);
         let pd_file = File::open(pd_filename)?;
         let pd: BTreeMap<String, PathDescriptorInfo> =
             serde_json::from_reader(BufReader::new(pd_file))?;
@@ -190,55 +197,3 @@ impl ControlInfo {
         Ok(out)
     }
 }
-
-// fn sort_path_descriptors(
-//     pd: PathDescriptorInfo,
-//     comp_to_ctrl: &mut HashMap<u32, ControlMeta>,
-// ) -> (HashMap<String, Option<u32>>) {
-//     // goal: Create a map from unique group name (unique call from control)
-//     // to the immediate control parent of the group, if one exists.
-//     let mut out: HashMap<String, Option<u32>> = HashMap::new();
-//
-//     let desc_to_ctrl_pos: HashMap<String, u32> = pd
-//         .control_pos
-//         .into_iter()
-//         .filter_map(|(d, ps)| {
-//             if let Some(p) =
-//                 ps.iter().filter(|p| comp_to_ctrl.contains_key(p)).next()
-//             {
-//                 Some((d, *p))
-//             } else {
-//                 None
-//             }
-//         })
-//         .collect();
-//
-//     let mut control_descriptors_sorted: Vec<&String> =
-//         desc_to_ctrl_pos.keys().collect();
-//     control_descriptors_sorted.sort();
-//     // get positions in ascending order
-//     let pos_orders = control_descriptors_sorted
-//         .iter()
-//         .map(|&k| *desc_to_ctrl_pos.get(k).unwrap())
-//         .collect();
-//     // reverse order to figure out groups' immediate predecessors
-//     control_descriptors_sorted.reverse();
-//
-//     // iterate through group descriptors and map keys
-//     for (g, d) in pd.enables.iter() {
-//         // find the immediate control node parent
-//         let mut found = false;
-//         for &cd in control_descriptors_sorted.iter() {
-//             if d.starts_with(cd) {
-//                 out.insert(g.clone(), Some(*desc_to_ctrl_pos.get(cd).unwrap()));
-//                 found = true;
-//                 break; // breaking because we found the first match
-//             }
-//         }
-//         if !found {
-//             out.insert(g.clone(), None);
-//         }
-//     }
-//
-//     (out, pos_orders)
-// }

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -1,13 +1,13 @@
 use anyhow::{Context, Ok, Result, anyhow};
 use cranelift_entity::{PrimaryMap, entity_impl};
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs::File,
     io::BufReader,
     path::Component,
 };
-
-use serde::{Deserialize, Serialize};
 
 use crate::control;
 
@@ -23,8 +23,8 @@ struct ControlCalyxPosInfo {
 // ORIGINALLY FROM uniquefy_enables Calyx pass
 // path_descriptor_infos: BTreeMap<String, PathDescriptorInfo>,
 /// Information to serialize for locating path descriptors
-#[derive(Serialize, Deserialize)]
-struct PathDescriptorInfo {
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PathDescriptorInfo {
     /// enable id --> descriptor
     pub enables: BTreeMap<String, String>,
     /// descriptor --> position set
@@ -110,46 +110,62 @@ pub struct ControlMeta {
     line_num: u32,
 }
 
-#[derive(Debug)]
-pub struct AllControl {
-    // can we clean this up somehow?
-    pub component_to_controls: HashMap<String, HashMap<u32, ControlMeta>>,
-    // for each component, record a group's most immediate parent
-    pub component_to_group_parent:
-        HashMap<String, HashMap<String, Option<u32>>>,
-    // for each component, record the stack of control positions (starting from bottom)
-    pub component_to_ctrl_stack: HashMap<String, Vec<u32>>,
+#[derive(Debug, Clone)]
+pub struct TdccInfo {
+    pub name: String,
 }
 
-impl AllControl {
+#[derive(Debug)]
+pub struct ControlInfo {
+    // Note: If the original program was written in an ADL, there would be multiple entries
+    // for the same TDCC group (for each position from the ADL)
+    // We also use a vector because multiple control nodes may map to the same position in the ADL
+    tdcc_map: FxHashMap<u32, Vec<TdccInfo>>,
+
+    // names for pretty printing
+    pretty_map: FxHashMap<u32, String>,
+
+    // info taken straight from the path-descriptors file
+    pd: BTreeMap<String, PathDescriptorInfo>,
+}
+
+impl ControlInfo {
+
+    pub fn descriptors(&self, c: &String) -> &PathDescriptorInfo {
+        self.pd.get(c.as_str()).unwrap()
+    }
+
+    pub fn get_pretty(&self, pos_set: &BTreeSet<u32>) -> Result<(String, u32)> {
+        for pos in pos_set.iter() {
+            if let Some(pretty) = self.pretty_map.get(&pos) {
+                return Ok((pretty.clone(), pos.clone()))
+            }
+        }
+        Err(anyhow!("Positions in {:?} not found in pretty map", pos_set))
+    }
+
+    pub fn get_tdcc(&self, pos: u32) -> Result<Vec<TdccInfo>> {
+
+    }
+
     pub fn new(
         tdcc_filename: String,
         pd_filename: String,
         pos_filename: String,
     ) -> Result<Self> {
-        let mut component_to_controls = HashMap::new();
+        let mut pp_name_map = FxHashMap::default();
+        let mut tdcc_map = FxHashMap::default();
 
         // need to process pos_file first because it gives us the Calyx positions of all control nodes.
         println!("Parsing {}", pos_filename);
         let pos_file = File::open(pos_filename)?;
         let pos: HashMap<String, Vec<ControlCalyxPosInfo>> =
             serde_json::from_reader(BufReader::new(pos_file))?;
-        for (component, pos_list) in pos {
-            let mut controls: HashMap<u32, ControlMeta> = HashMap::new();
+        for (_component, pos_list) in pos {
             for pos in pos_list {
-                controls.insert(
-                    pos.pos_num,
-                    ControlMeta {
-                        name: "".to_string(), // will be filled in by tdcc_file
-                        component: component.clone(),
-                        control_type: pos.ctrl_node,
-                        registers: None, // will be filled in by tdcc_file
-                        pos: pos.pos_num,
-                        line_num: pos.linenum,
-                    },
-                );
+                let pp_name = format!("L{}:{}", pos.linenum, pos.ctrl_node);
+                pp_name_map.insert(pos.pos_num, pp_name);
             }
-            component_to_controls.insert(component, controls);
         }
 
         println!("Parsing {}", tdcc_filename);
@@ -158,80 +174,43 @@ impl AllControl {
             serde_json::from_reader(BufReader::new(tdcc_file))?;
         // some control nodes may have been compiled away due to optimizations, etc.
         // need to filter nodes that don't remain in code.
-        let mut existing_ctrl_nodes: HashSet<u32> = HashSet::new();
         for control_group in tdcc_profiling_info {
             match control_group {
                 ProfilingInfo::Fsm(fsminfo) => {
-                    // search component_to_controls for the entry that matches this FSM
-                    let mut found = false;
-                    let comp_ctrl_map = component_to_controls
-                        .get_mut(&fsminfo.component)
-                        .unwrap();
                     for pos in fsminfo.pos {
-                        // there can be multiple positions because of ADL metadata mapping.
-                        if let Some(c) = comp_ctrl_map.get_mut(&pos) {
-                            c.name = fsminfo.group.clone();
-                            c.registers =
-                                Some(ControlRegister::FSM(fsminfo.fsm.clone()));
-                            found = true;
-                            existing_ctrl_nodes.insert(pos);
-                        }
+                        tdcc_map.entry(pos).or_insert(vec![]).push(TdccInfo { name: fsminfo.group.clone() });
                     }
-                    assert!(found);
                 }
                 ProfilingInfo::Par(par_info) => {
-                    // search component_to_controls for the entry that matches this par group
-                    let mut found = false;
-                    let comp_ctrl_map = component_to_controls
-                        .get_mut(&par_info.component)
-                        .unwrap();
                     for pos in par_info.pos {
-                        // there can be multiple positions because of ADL metadata mapping.
-                        if let Some(c) = comp_ctrl_map.get_mut(&pos) {
-                            c.name = par_info.par_group.clone();
-                            let mut child_group_dones = Vec::new();
-                            // collect all `pd` registers from each child.
-                            for child in par_info.child_groups.iter() {
-                                child_group_dones.push(child.register.clone());
-                            }
-                            c.registers =
-                                Some(ControlRegister::PD(child_group_dones));
-                            found = true;
-                            existing_ctrl_nodes.insert(pos);
-                        }
+                        tdcc_map.entry(pos).or_insert(vec![]).push(TdccInfo { name: par_info.par_group });
                     }
-                    assert!(found);
                 }
                 ProfilingInfo::SingleEnable(_single_enable_info) => { // do nothing since there is no control group
                 }
             }
         }
 
-        // filter out any control nodes that were compiled away
-        for (_, m) in component_to_controls.iter_mut() {
-            m.retain(|k, _| existing_ctrl_nodes.contains(k));
-        }
-
         println!("Parsing {}", pd_filename);
         let pd_file = File::open(pd_filename)?;
         let pd: BTreeMap<String, PathDescriptorInfo> =
             serde_json::from_reader(BufReader::new(pd_file))?;
-        let mut component_to_group_parent = HashMap::new();
-        let mut component_to_ctrl_stack = HashMap::new();
-        for (component, comp_pd) in pd {
-            let (group_to_parent, control_stack) = sort_path_descriptors(
-                comp_pd,
-                component_to_controls.get_mut(&component).unwrap(),
-            );
-            component_to_group_parent
-                .insert(component.clone(), group_to_parent);
-            component_to_ctrl_stack.insert(component, control_stack);
-        }
+        // let mut component_to_group_parent = HashMap::new();
+        // let mut component_to_ctrl_stack = HashMap::new();
+        // for (component, comp_pd) in pd {
+        //     let (group_to_parent, control_stack) = sort_path_descriptors(
+        //         comp_pd,
+        //         component_to_controls.get_mut(&component).unwrap(),
+        //     );
+        //     component_to_group_parent
+        //         .insert(component.clone(), group_to_parent);
+        //     component_to_ctrl_stack.insert(component, control_stack);
+        // }
 
         let out = Self {
-            component_to_controls,
-            component_to_group_parent,
-            component_to_ctrl_stack,
+            tdcc_map,
+            pretty_map: pp_name_map,
+            pd
         };
 
         println!("{out:?}");
@@ -240,54 +219,54 @@ impl AllControl {
     }
 }
 
-fn sort_path_descriptors(
-    pd: PathDescriptorInfo,
-    comp_to_ctrl: &mut HashMap<u32, ControlMeta>,
-) -> (HashMap<String, Option<u32>>, Vec<u32>) {
-    // goal: Create a map from unique group name (unique call from control)
-    // to the immediate control parent of the group, if one exists.
-    let mut out: HashMap<String, Option<u32>> = HashMap::new();
-
-    let desc_to_ctrl_pos: HashMap<String, u32> = pd
-        .control_pos
-        .into_iter()
-        .filter_map(|(d, ps)| {
-            if let Some(p) =
-                ps.iter().filter(|p| comp_to_ctrl.contains_key(p)).next()
-            {
-                Some((d, *p))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    let mut control_descriptors_sorted: Vec<&String> =
-        desc_to_ctrl_pos.keys().collect();
-    control_descriptors_sorted.sort();
-    // get positions in ascending order
-    let pos_orders = control_descriptors_sorted
-        .iter()
-        .map(|&k| *desc_to_ctrl_pos.get(k).unwrap())
-        .collect();
-    // reverse order to figure out groups' immediate predecessors
-    control_descriptors_sorted.reverse();
-
-    // iterate through group descriptors and map keys
-    for (g, d) in pd.enables.iter() {
-        // find the immediate control node parent
-        let mut found = false;
-        for &cd in control_descriptors_sorted.iter() {
-            if d.starts_with(cd) {
-                out.insert(g.clone(), Some(*desc_to_ctrl_pos.get(cd).unwrap()));
-                found = true;
-                break; // breaking because we found the first match
-            }
-        }
-        if !found {
-            out.insert(g.clone(), None);
-        }
-    }
-
-    (out, pos_orders)
-}
+// fn sort_path_descriptors(
+//     pd: PathDescriptorInfo,
+//     comp_to_ctrl: &mut HashMap<u32, ControlMeta>,
+// ) -> (HashMap<String, Option<u32>>) {
+//     // goal: Create a map from unique group name (unique call from control)
+//     // to the immediate control parent of the group, if one exists.
+//     let mut out: HashMap<String, Option<u32>> = HashMap::new();
+//
+//     let desc_to_ctrl_pos: HashMap<String, u32> = pd
+//         .control_pos
+//         .into_iter()
+//         .filter_map(|(d, ps)| {
+//             if let Some(p) =
+//                 ps.iter().filter(|p| comp_to_ctrl.contains_key(p)).next()
+//             {
+//                 Some((d, *p))
+//             } else {
+//                 None
+//             }
+//         })
+//         .collect();
+//
+//     let mut control_descriptors_sorted: Vec<&String> =
+//         desc_to_ctrl_pos.keys().collect();
+//     control_descriptors_sorted.sort();
+//     // get positions in ascending order
+//     let pos_orders = control_descriptors_sorted
+//         .iter()
+//         .map(|&k| *desc_to_ctrl_pos.get(k).unwrap())
+//         .collect();
+//     // reverse order to figure out groups' immediate predecessors
+//     control_descriptors_sorted.reverse();
+//
+//     // iterate through group descriptors and map keys
+//     for (g, d) in pd.enables.iter() {
+//         // find the immediate control node parent
+//         let mut found = false;
+//         for &cd in control_descriptors_sorted.iter() {
+//             if d.starts_with(cd) {
+//                 out.insert(g.clone(), Some(*desc_to_ctrl_pos.get(cd).unwrap()));
+//                 found = true;
+//                 break; // breaking because we found the first match
+//             }
+//         }
+//         if !found {
+//             out.insert(g.clone(), None);
+//         }
+//     }
+//
+//     (out, pos_orders)
+// }

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -100,8 +100,8 @@ enum ControlRegister {
 }
 
 #[derive(Debug)]
-struct ControlMeta {
-    name: String, // name of the TDCC group (later changed into signal?)
+pub struct ControlMeta {
+    pub name: String, // name of the TDCC group (later changed into signal?)
     // groups: Vec<String>, // groups that are invoked under this control node
     component: String,
     control_type: String, // seq, par, etc. optimize into enum?
@@ -141,7 +141,6 @@ impl AllControl {
                     pos.pos_num,
                     ControlMeta {
                         name: "".to_string(), // will be filled in by tdcc_file
-                        // groups: vec![],       // will be filled in by pd_file
                         component: component.clone(),
                         control_type: pos.ctrl_node,
                         registers: None, // will be filled in by tdcc_file

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -122,7 +122,6 @@ pub struct ControlInfo {
 }
 
 impl ControlInfo {
-
     pub fn descriptors(&self, c: &str) -> &PathDescriptorInfo {
         self.pd.get(c).unwrap()
     }
@@ -130,10 +129,13 @@ impl ControlInfo {
     pub fn get_pretty(&self, pos_set: &BTreeSet<u32>) -> Result<(String, u32)> {
         for pos in pos_set.iter() {
             if let Some(pretty) = self.pretty_map.get(pos) {
-                return Ok((pretty.clone(), *pos))
+                return Ok((pretty.clone(), *pos));
             }
         }
-        Err(anyhow!("Positions in {:?} not found in pretty map", pos_set))
+        Err(anyhow!(
+            "Positions in {:?} not found in pretty map",
+            pos_set
+        ))
     }
 
     pub fn get_tdcc(&self, pos: u32) -> Result<Option<&Vec<TdccInfo>>> {
@@ -170,12 +172,16 @@ impl ControlInfo {
             match control_group {
                 ProfilingInfo::Fsm(fsminfo) => {
                     for pos in fsminfo.pos {
-                        tdcc_map.entry(pos).or_insert(vec![]).push(TdccInfo { name: fsminfo.group.clone() });
+                        tdcc_map.entry(pos).or_insert(vec![]).push(TdccInfo {
+                            name: fsminfo.group.clone(),
+                        });
                     }
                 }
                 ProfilingInfo::Par(par_info) => {
                     for pos in par_info.pos {
-                        tdcc_map.entry(pos).or_insert(vec![]).push(TdccInfo { name: par_info.par_group.clone() });
+                        tdcc_map.entry(pos).or_insert(vec![]).push(TdccInfo {
+                            name: par_info.par_group.clone(),
+                        });
                     }
                 }
                 ProfilingInfo::SingleEnable(_single_enable_info) => { // do nothing since there is no control group
@@ -191,7 +197,7 @@ impl ControlInfo {
         let out = Self {
             tdcc_map,
             pretty_map: pp_name_map,
-            pd
+            pd,
         };
 
         Ok(out)

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -9,13 +9,12 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+use crate::control;
+
 // ORIGINALLY FROM fileinfo_emitter tool
 // Obtaining the original line numbers of Calyx
 #[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct ControlCalyxPosInfo {
-    // TODO: Probably good to add filename as well in case the Calyx component
-    // TODO: Also we need to make sure that we pull out the line number from Calyx (check if file is .futil)
-    // pub filename: String,
     pub pos_num: u32,
     pub linenum: u32,
     pub ctrl_node: String,
@@ -114,8 +113,12 @@ struct ControlMeta {
 #[derive(Debug)]
 pub struct AllControl {
     // can we clean this up somehow?
-    component_to_controls: HashMap<String, HashMap<u32, ControlMeta>>,
-    component_to_group_parents: HashMap<String, HashMap<String, Vec<u32>>>,
+    pub component_to_controls: HashMap<String, HashMap<u32, ControlMeta>>,
+    // for each component, record a group's most immediate parent
+    pub component_to_group_parent:
+        HashMap<String, HashMap<String, Option<u32>>>,
+    // for each component, record the stack of control positions (starting from bottom)
+    pub component_to_ctrl_stack: HashMap<String, Vec<u32>>,
 }
 
 impl AllControl {
@@ -214,18 +217,22 @@ impl AllControl {
         let pd_file = File::open(pd_filename)?;
         let pd: BTreeMap<String, PathDescriptorInfo> =
             serde_json::from_reader(BufReader::new(pd_file))?;
-        let mut component_to_group_parents = HashMap::new();
+        let mut component_to_group_parent = HashMap::new();
+        let mut component_to_ctrl_stack = HashMap::new();
         for (component, comp_pd) in pd {
-            let group_to_parents = sort_path_descriptors(
+            let (group_to_parent, control_stack) = sort_path_descriptors(
                 comp_pd,
                 component_to_controls.get_mut(&component).unwrap(),
             );
-            component_to_group_parents.insert(component, group_to_parents);
+            component_to_group_parent
+                .insert(component.clone(), group_to_parent);
+            component_to_ctrl_stack.insert(component, control_stack);
         }
 
         let out = Self {
             component_to_controls,
-            component_to_group_parents,
+            component_to_group_parent,
+            component_to_ctrl_stack,
         };
 
         println!("{out:?}");
@@ -237,10 +244,10 @@ impl AllControl {
 fn sort_path_descriptors(
     pd: PathDescriptorInfo,
     comp_to_ctrl: &mut HashMap<u32, ControlMeta>,
-) -> HashMap<String, Vec<u32>> {
+) -> (HashMap<String, Option<u32>>, Vec<u32>) {
     // goal: Create a map from unique group name (unique call from control)
-    // to a list of parent control nodes pos.
-    let mut out: HashMap<String, Vec<u32>> = HashMap::new();
+    // to the immediate control parent of the group, if one exists.
+    let mut out: HashMap<String, Option<u32>> = HashMap::new();
 
     let desc_to_ctrl_pos: HashMap<String, u32> = pd
         .control_pos
@@ -255,21 +262,33 @@ fn sort_path_descriptors(
             }
         })
         .collect();
+
     let mut control_descriptors_sorted: Vec<&String> =
         desc_to_ctrl_pos.keys().collect();
     control_descriptors_sorted.sort();
+    // get positions in ascending order
+    let pos_orders = control_descriptors_sorted
+        .iter()
+        .map(|&k| *desc_to_ctrl_pos.get(k).unwrap())
+        .collect();
+    // reverse order to figure out groups' immediate predecessors
+    control_descriptors_sorted.reverse();
 
     // iterate through group descriptors and map keys
     for (g, d) in pd.enables.iter() {
-        // find all control descriptors that are prefixes of this group's descriptor
-        let mut prefix_controls: Vec<u32> = vec![];
+        // find the immediate control node parent
+        let mut found = false;
         for &cd in control_descriptors_sorted.iter() {
             if d.starts_with(cd) {
-                prefix_controls.push(*desc_to_ctrl_pos.get(cd).unwrap());
+                out.insert(g.clone(), Some(*desc_to_ctrl_pos.get(cd).unwrap()));
+                found = true;
+                break; // breaking because we found the first match
             }
         }
-        out.insert(g.clone(), prefix_controls);
+        if !found {
+            out.insert(g.clone(), None);
+        }
     }
 
-    out
+    (out, pos_orders)
 }

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -1,15 +1,15 @@
 use anyhow::{Ok, Result, anyhow};
 use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fs::File,
     io::BufReader,
 };
 
 // ORIGINALLY FROM fileinfo_emitter tool
 // Obtaining the original line numbers of Calyx
-#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Deserialize)]
 struct ControlCalyxPosInfo {
     pub pos_num: u32,
     pub linenum: u32,
@@ -19,19 +19,19 @@ struct ControlCalyxPosInfo {
 // ORIGINALLY FROM uniquefy_enables Calyx pass
 // path_descriptor_infos: BTreeMap<String, PathDescriptorInfo>,
 /// Information to serialize for locating path descriptors
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct PathDescriptorInfo {
     /// enable id --> descriptor
-    pub enables: BTreeMap<String, String>,
+    pub enables: FxHashMap<String, String>,
     /// descriptor --> position set
     /// (Ideally I'd do a position set --> descriptor mapping but
     /// a set shouldn't be a key.)
-    pub control_pos: BTreeMap<String, BTreeSet<u32>>,
+    pub control_pos: FxHashMap<String, BTreeSet<u32>>,
 }
 
 /// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
 /// Information to serialize for profiling purposes
-#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Hash, Eq, PartialEq, Deserialize)]
 enum ProfilingInfo {
     Fsm(FSMInfo),
     Par(ParInfo),
@@ -41,14 +41,14 @@ enum ProfilingInfo {
 /// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
 /// Information to be serialized for a group that isn't managed by a FSM
 /// This can happen if the group is the only group in a control block or a par arm
-#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Hash, Eq, PartialEq, Deserialize)]
 struct SingleEnableInfo {
     pub component: String,
     pub group: String,
 }
 
 /// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
-#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Hash, Eq, PartialEq, Deserialize)]
 struct ParInfo {
     pub component: String,
     pub par_group: String,
@@ -59,7 +59,7 @@ struct ParInfo {
 }
 
 /// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
-#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Hash, Eq, PartialEq, Deserialize)]
 struct ParChildInfo {
     pub group: String,
     pub register: String,
@@ -67,7 +67,7 @@ struct ParChildInfo {
 
 /// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
 /// Information to be serialized for a single FSM
-#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Hash, Eq, PartialEq, Deserialize)]
 struct FSMInfo {
     pub component: String,
     pub group: String,
@@ -80,9 +80,7 @@ struct FSMInfo {
 
 /// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
 /// Mapping of FSM state ids to corresponding group names
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize,
-)]
+#[derive(Hash, Eq, PartialEq, Deserialize)]
 struct FSMStateInfo {
     id: u64,
     group: String,
@@ -118,7 +116,7 @@ pub struct ControlInfo {
 
     /// info taken straight from the path-descriptors file (for computing parent-child relationships
     /// between control groups & groups.
-    pd: BTreeMap<String, PathDescriptorInfo>,
+    pd: FxHashMap<String, PathDescriptorInfo>,
 }
 
 impl ControlInfo {
@@ -191,7 +189,7 @@ impl ControlInfo {
 
         log::debug!("Parsing {}", pd_filename);
         let pd_file = File::open(pd_filename)?;
-        let pd: BTreeMap<String, PathDescriptorInfo> =
+        let pd: FxHashMap<String, PathDescriptorInfo> =
             serde_json::from_reader(BufReader::new(pd_file))?;
 
         let out = Self {

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -1,6 +1,6 @@
 use anyhow::{Ok, Result, anyhow};
 use rustc_hash::FxHashMap;
-use serde::{Deserialize};
+use serde::Deserialize;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fs::File,

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -116,14 +116,14 @@ pub struct ControlInfo {
 
 impl ControlInfo {
 
-    pub fn descriptors(&self, c: &String) -> &PathDescriptorInfo {
-        self.pd.get(c.as_str()).unwrap()
+    pub fn descriptors(&self, c: &str) -> &PathDescriptorInfo {
+        self.pd.get(c).unwrap()
     }
 
     pub fn get_pretty(&self, pos_set: &BTreeSet<u32>) -> Result<(String, u32)> {
         for pos in pos_set.iter() {
-            if let Some(pretty) = self.pretty_map.get(&pos) {
-                return Ok((pretty.clone(), pos.clone()))
+            if let Some(pretty) = self.pretty_map.get(pos) {
+                return Ok((pretty.clone(), *pos))
             }
         }
         Err(anyhow!("Positions in {:?} not found in pretty map", pos_set))

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs::File,
     io::BufReader,
+    path::Component,
 };
 
 use serde::{Deserialize, Serialize};
@@ -92,16 +93,17 @@ struct FSMStateInfo {
     group: String,
 }
 
-/// Represents the registers that do the bookkeeping for a
-/// control group
+/// Represents the registers that do the bookkeeping for a control group
+#[derive(Debug)]
 enum ControlRegister {
     FSM(String),
     PD(Vec<String>),
 }
 
+#[derive(Debug)]
 struct ControlMeta {
     name: String, // name of the TDCC group (later changed into signal?)
-    groups: Vec<String>, // groups that are invoked under this control node
+    // groups: Vec<String>, // groups that are invoked under this control node
     component: String,
     control_type: String, // seq, par, etc. optimize into enum?
     registers: Option<ControlRegister>,
@@ -109,8 +111,11 @@ struct ControlMeta {
     line_num: u32,
 }
 
-struct AllControl {
+#[derive(Debug)]
+pub struct AllControl {
+    // can we clean this up somehow?
     component_to_controls: HashMap<String, HashMap<u32, ControlMeta>>,
+    component_to_group_parents: HashMap<String, HashMap<String, Vec<u32>>>,
 }
 
 impl AllControl {
@@ -133,7 +138,7 @@ impl AllControl {
                     pos.pos_num,
                     ControlMeta {
                         name: "".to_string(), // will be filled in by tdcc_file
-                        groups: vec![],       // will be filled in by pd_file
+                        // groups: vec![],       // will be filled in by pd_file
                         component: component.clone(),
                         control_type: pos.ctrl_node,
                         registers: None, // will be filled in by tdcc_file
@@ -149,6 +154,9 @@ impl AllControl {
         let tdcc_file = File::open(tdcc_filename)?;
         let tdcc_profiling_info: HashSet<ProfilingInfo> =
             serde_json::from_reader(BufReader::new(tdcc_file))?;
+        // some control nodes may have been compiled away due to optimizations, etc.
+        // need to filter nodes that don't remain in code.
+        let mut existing_ctrl_nodes: HashSet<u32> = HashSet::new();
         for control_group in tdcc_profiling_info {
             match control_group {
                 ProfilingInfo::Fsm(fsminfo) => {
@@ -158,68 +166,110 @@ impl AllControl {
                         .get_mut(&fsminfo.component)
                         .unwrap();
                     for pos in fsminfo.pos {
-                        // there can be multiple positions because of
+                        // there can be multiple positions because of ADL metadata mapping.
                         if let Some(c) = comp_ctrl_map.get_mut(&pos) {
                             c.name = fsminfo.group.clone();
                             c.registers =
                                 Some(ControlRegister::FSM(fsminfo.fsm.clone()));
                             found = true;
+                            existing_ctrl_nodes.insert(pos);
                         }
                     }
                     assert!(found);
                 }
                 ProfilingInfo::Par(par_info) => {
                     // search component_to_controls for the entry that matches this par group
+                    let mut found = false;
+                    let comp_ctrl_map = component_to_controls
+                        .get_mut(&par_info.component)
+                        .unwrap();
+                    for pos in par_info.pos {
+                        // there can be multiple positions because of ADL metadata mapping.
+                        if let Some(c) = comp_ctrl_map.get_mut(&pos) {
+                            c.name = par_info.par_group.clone();
+                            let mut child_group_dones = Vec::new();
+                            // collect all `pd` registers from each child.
+                            for child in par_info.child_groups.iter() {
+                                child_group_dones.push(child.register.clone());
+                            }
+                            c.registers =
+                                Some(ControlRegister::PD(child_group_dones));
+                            found = true;
+                            existing_ctrl_nodes.insert(pos);
+                        }
+                    }
+                    assert!(found);
                 }
                 ProfilingInfo::SingleEnable(_single_enable_info) => { // do nothing since there is no control group
                 }
             }
         }
 
+        // filter out any control nodes that were compiled away
+        for (_, m) in component_to_controls.iter_mut() {
+            m.retain(|k, _| existing_ctrl_nodes.contains(k));
+        }
+
         println!("Parsing {}", pd_filename);
         let pd_file = File::open(pd_filename)?;
         let pd: BTreeMap<String, PathDescriptorInfo> =
             serde_json::from_reader(BufReader::new(pd_file))?;
+        let mut component_to_group_parents = HashMap::new();
+        for (component, comp_pd) in pd {
+            let group_to_parents = sort_path_descriptors(
+                comp_pd,
+                component_to_controls.get_mut(&component).unwrap(),
+            );
+            component_to_group_parents.insert(component, group_to_parents);
+        }
 
-        let mut out = Self {
+        let out = Self {
             component_to_controls,
+            component_to_group_parents,
         };
+
+        println!("{out:?}");
+
         Ok(out)
     }
-    // pub fn parse(
-    //     tdcc_filename: String,
-    //     pd_filename: String,
-    //     pos_filename: String,
-    // ) -> Result<()> {
-    //     println!("Parsing {}", tdcc_filename);
-    //     let tdcc_file = File::open(tdcc_filename)?;
-    //     let tdcc_profiling_info: HashSet<ProfilingInfo> =
-    //         serde_json::from_reader(BufReader::new(tdcc_file))?;
-
-    //     println!("Parsing {}", pd_filename);
-    //     let pd_file = File::open(pd_filename)?;
-    //     let pd: BTreeMap<String, PathDescriptorInfo> =
-    //         serde_json::from_reader(BufReader::new(pd_file))?;
-
-    //     println!("Parsing {}", pos_filename);
-    //     let pos_file = File::open(pos_filename)?;
-    //     let pos: HashMap<String, Vec<ControlCalyxPosInfo>> =
-    //         serde_json::from_reader(BufReader::new(pos_file))?;
-
-    //     Ok(())
-    // }
 }
 
-// #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
-// pub struct ControlId(u32);
-// entity_impl!(ControlId, "control");
+fn sort_path_descriptors(
+    pd: PathDescriptorInfo,
+    comp_to_ctrl: &mut HashMap<u32, ControlMeta>,
+) -> HashMap<String, Vec<u32>> {
+    // goal: Create a map from unique group name (unique call from control)
+    // to a list of parent control nodes pos.
+    let mut out: HashMap<String, Vec<u32>> = HashMap::new();
 
-// #[derive(Debug, Clone)]
+    let desc_to_ctrl_pos: HashMap<String, u32> = pd
+        .control_pos
+        .into_iter()
+        .filter_map(|(d, ps)| {
+            if let Some(p) =
+                ps.iter().filter(|p| comp_to_ctrl.contains_key(p)).next()
+            {
+                Some((d, *p))
+            } else {
+                None
+            }
+        })
+        .collect();
+    let mut control_descriptors_sorted: Vec<&String> =
+        desc_to_ctrl_pos.keys().collect();
+    control_descriptors_sorted.sort();
 
-// struct Control {
-//     name: String,
+    // iterate through group descriptors and map keys
+    for (g, d) in pd.enables.iter() {
+        // find all control descriptors that are prefixes of this group's descriptor
+        let mut prefix_controls: Vec<u32> = vec![];
+        for &cd in control_descriptors_sorted.iter() {
+            if d.starts_with(cd) {
+                prefix_controls.push(*desc_to_ctrl_pos.get(cd).unwrap());
+            }
+        }
+        out.insert(g.clone(), prefix_controls);
+    }
 
-//     // probe: SignalRef,
-//     // invokes: SmallVec<[InvokeId; 6]>,
-//     // probe_idx: u32,
-// }
+    out
+}

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -1,0 +1,115 @@
+use anyhow::{Context, Ok, Result, anyhow};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    fs::File,
+    io::BufReader,
+};
+
+use serde::{Deserialize, Serialize};
+
+// ORIGINALLY FROM fileinfo_emitter tool
+// Obtaining the original line numbers of Calyx
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct ControlCalyxPosInfo {
+    // TODO: Probably good to add filename as well in case the Calyx component
+    // TODO: Also we need to make sure that we pull out the line number from Calyx (check if file is .futil)
+    // pub filename: String,
+    pub pos_num: u32,
+    pub linenum: u32,
+    pub ctrl_node: String,
+}
+
+// ORIGINALLY FROM uniquefy_enables Calyx pass
+// path_descriptor_infos: BTreeMap<String, PathDescriptorInfo>,
+/// Information to serialize for locating path descriptors
+#[derive(Serialize, Deserialize)]
+struct PathDescriptorInfo {
+    /// enable id --> descriptor
+    pub enables: BTreeMap<String, String>,
+    /// descriptor --> position set
+    /// (Stringeally I'd do a position set --> descriptor mapping but
+    /// a set shouldn't be a key.)
+    pub control_pos: BTreeMap<String, BTreeSet<u32>>,
+}
+
+/// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
+/// Information to serialize for profiling purposes
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+enum ProfilingInfo {
+    Fsm(FSMInfo),
+    Par(ParInfo),
+    SingleEnable(SingleEnableInfo),
+}
+
+/// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
+/// Information to be serialized for a group that isn't managed by a FSM
+/// This can happen if the group is the only group in a control block or a par arm
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct SingleEnableInfo {
+    pub component: String,
+    pub group: String,
+}
+
+/// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct ParInfo {
+    pub component: String,
+    pub par_group: String,
+    pub child_groups: Vec<ParChildInfo>,
+    /// Values in the position set attribute that was associated with the control par node
+    /// that generated this par group.
+    pub pos: Vec<u32>,
+}
+
+/// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct ParChildInfo {
+    pub group: String,
+    pub register: String,
+}
+
+/// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
+/// Information to be serialized for a single FSM
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct FSMInfo {
+    pub component: String,
+    pub group: String,
+    pub fsm: String,
+    pub states: Vec<FSMStateInfo>,
+    /// Values in the position set attribute that was associated with the control node
+    /// that generated the TDCC group.
+    pub pos: Vec<u32>,
+}
+
+/// ORIGINALLY FROM TDCC Calyx pass; replaced all instances of Id with String
+/// Mapping of FSM state ids to corresponding group names
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize,
+)]
+struct FSMStateInfo {
+    id: u64,
+    group: String,
+}
+
+pub fn parse(
+    tdcc_filename: String,
+    pd_filename: String,
+    pos_filename: String,
+) -> Result<()> {
+    println!("Parsing {}", tdcc_filename);
+    let tdcc_file = File::open(tdcc_filename)?;
+    let tdcc_profiling_info: HashSet<ProfilingInfo> =
+        serde_json::from_reader(BufReader::new(tdcc_file))?;
+
+    println!("Parsing {}", pd_filename);
+    let pd_file = File::open(pd_filename)?;
+    let pd: BTreeMap<String, PathDescriptorInfo> =
+        serde_json::from_reader(BufReader::new(pd_file))?;
+
+    println!("Parsing {}", pos_filename);
+    let pos_file = File::open(pos_filename)?;
+    let pos: HashMap<String, Vec<ControlCalyxPosInfo>> =
+        serde_json::from_reader(BufReader::new(pos_file))?;
+
+    Ok(())
+}

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -1,15 +1,11 @@
-use anyhow::{Context, Ok, Result, anyhow};
-use cranelift_entity::{PrimaryMap, entity_impl};
+use anyhow::{Ok, Result, anyhow};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs::File,
     io::BufReader,
-    path::Component,
 };
-
-use crate::control;
 
 // ORIGINALLY FROM fileinfo_emitter tool
 // Obtaining the original line numbers of Calyx
@@ -93,22 +89,11 @@ struct FSMStateInfo {
 }
 
 /// Represents the registers that do the bookkeeping for a control group
-#[derive(Debug)]
-enum ControlRegister {
-    FSM(String),
-    PD(Vec<String>),
-}
-
-#[derive(Debug)]
-pub struct ControlMeta {
-    pub name: String, // name of the TDCC group (later changed into signal?)
-    // groups: Vec<String>, // groups that are invoked under this control node
-    component: String,
-    control_type: String, // seq, par, etc. optimize into enum?
-    registers: Option<ControlRegister>,
-    pos: u32,
-    line_num: u32,
-}
+// #[derive(Debug)]
+// enum ControlRegister {
+//     FSM(String),
+//     PD(Vec<String>),
+// }
 
 #[derive(Debug, Clone)]
 pub struct TdccInfo {
@@ -144,8 +129,8 @@ impl ControlInfo {
         Err(anyhow!("Positions in {:?} not found in pretty map", pos_set))
     }
 
-    pub fn get_tdcc(&self, pos: u32) -> Result<Vec<TdccInfo>> {
-
+    pub fn get_tdcc(&self, pos: u32) -> Result<Option<&Vec<TdccInfo>>> {
+        Ok(self.tdcc_map.get(&pos))
     }
 
     pub fn new(
@@ -183,7 +168,7 @@ impl ControlInfo {
                 }
                 ProfilingInfo::Par(par_info) => {
                     for pos in par_info.pos {
-                        tdcc_map.entry(pos).or_insert(vec![]).push(TdccInfo { name: par_info.par_group });
+                        tdcc_map.entry(pos).or_insert(vec![]).push(TdccInfo { name: par_info.par_group.clone() });
                     }
                 }
                 ProfilingInfo::SingleEnable(_single_enable_info) => { // do nothing since there is no control group

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Ok, Result, anyhow};
+use cranelift_entity::{PrimaryMap, entity_impl};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs::File,
@@ -27,7 +28,7 @@ struct PathDescriptorInfo {
     /// enable id --> descriptor
     pub enables: BTreeMap<String, String>,
     /// descriptor --> position set
-    /// (Stringeally I'd do a position set --> descriptor mapping but
+    /// (Ideally I'd do a position set --> descriptor mapping but
     /// a set shouldn't be a key.)
     pub control_pos: BTreeMap<String, BTreeSet<u32>>,
 }
@@ -91,25 +92,134 @@ struct FSMStateInfo {
     group: String,
 }
 
-pub fn parse(
-    tdcc_filename: String,
-    pd_filename: String,
-    pos_filename: String,
-) -> Result<()> {
-    println!("Parsing {}", tdcc_filename);
-    let tdcc_file = File::open(tdcc_filename)?;
-    let tdcc_profiling_info: HashSet<ProfilingInfo> =
-        serde_json::from_reader(BufReader::new(tdcc_file))?;
-
-    println!("Parsing {}", pd_filename);
-    let pd_file = File::open(pd_filename)?;
-    let pd: BTreeMap<String, PathDescriptorInfo> =
-        serde_json::from_reader(BufReader::new(pd_file))?;
-
-    println!("Parsing {}", pos_filename);
-    let pos_file = File::open(pos_filename)?;
-    let pos: HashMap<String, Vec<ControlCalyxPosInfo>> =
-        serde_json::from_reader(BufReader::new(pos_file))?;
-
-    Ok(())
+/// Represents the registers that do the bookkeeping for a
+/// control group
+enum ControlRegister {
+    FSM(String),
+    PD(Vec<String>),
 }
+
+struct ControlMeta {
+    name: String, // name of the TDCC group (later changed into signal?)
+    groups: Vec<String>, // groups that are invoked under this control node
+    component: String,
+    control_type: String, // seq, par, etc. optimize into enum?
+    registers: Option<ControlRegister>,
+    pos: u32,
+    line_num: u32,
+}
+
+struct AllControl {
+    component_to_controls: HashMap<String, HashMap<u32, ControlMeta>>,
+}
+
+impl AllControl {
+    pub fn new(
+        tdcc_filename: String,
+        pd_filename: String,
+        pos_filename: String,
+    ) -> Result<Self> {
+        let mut component_to_controls = HashMap::new();
+
+        // need to process pos_file first because it gives us the Calyx positions of all control nodes.
+        println!("Parsing {}", pos_filename);
+        let pos_file = File::open(pos_filename)?;
+        let pos: HashMap<String, Vec<ControlCalyxPosInfo>> =
+            serde_json::from_reader(BufReader::new(pos_file))?;
+        for (component, pos_list) in pos {
+            let mut controls: HashMap<u32, ControlMeta> = HashMap::new();
+            for pos in pos_list {
+                controls.insert(
+                    pos.pos_num,
+                    ControlMeta {
+                        name: "".to_string(), // will be filled in by tdcc_file
+                        groups: vec![],       // will be filled in by pd_file
+                        component: component.clone(),
+                        control_type: pos.ctrl_node,
+                        registers: None, // will be filled in by tdcc_file
+                        pos: pos.pos_num,
+                        line_num: pos.linenum,
+                    },
+                );
+            }
+            component_to_controls.insert(component, controls);
+        }
+
+        println!("Parsing {}", tdcc_filename);
+        let tdcc_file = File::open(tdcc_filename)?;
+        let tdcc_profiling_info: HashSet<ProfilingInfo> =
+            serde_json::from_reader(BufReader::new(tdcc_file))?;
+        for control_group in tdcc_profiling_info {
+            match control_group {
+                ProfilingInfo::Fsm(fsminfo) => {
+                    // search component_to_controls for the entry that matches this FSM
+                    let mut found = false;
+                    let comp_ctrl_map = component_to_controls
+                        .get_mut(&fsminfo.component)
+                        .unwrap();
+                    for pos in fsminfo.pos {
+                        // there can be multiple positions because of
+                        if let Some(c) = comp_ctrl_map.get_mut(&pos) {
+                            c.name = fsminfo.group.clone();
+                            c.registers =
+                                Some(ControlRegister::FSM(fsminfo.fsm.clone()));
+                            found = true;
+                        }
+                    }
+                    assert!(found);
+                }
+                ProfilingInfo::Par(par_info) => {
+                    // search component_to_controls for the entry that matches this par group
+                }
+                ProfilingInfo::SingleEnable(_single_enable_info) => { // do nothing since there is no control group
+                }
+            }
+        }
+
+        println!("Parsing {}", pd_filename);
+        let pd_file = File::open(pd_filename)?;
+        let pd: BTreeMap<String, PathDescriptorInfo> =
+            serde_json::from_reader(BufReader::new(pd_file))?;
+
+        let mut out = Self {
+            component_to_controls,
+        };
+        Ok(out)
+    }
+    // pub fn parse(
+    //     tdcc_filename: String,
+    //     pd_filename: String,
+    //     pos_filename: String,
+    // ) -> Result<()> {
+    //     println!("Parsing {}", tdcc_filename);
+    //     let tdcc_file = File::open(tdcc_filename)?;
+    //     let tdcc_profiling_info: HashSet<ProfilingInfo> =
+    //         serde_json::from_reader(BufReader::new(tdcc_file))?;
+
+    //     println!("Parsing {}", pd_filename);
+    //     let pd_file = File::open(pd_filename)?;
+    //     let pd: BTreeMap<String, PathDescriptorInfo> =
+    //         serde_json::from_reader(BufReader::new(pd_file))?;
+
+    //     println!("Parsing {}", pos_filename);
+    //     let pos_file = File::open(pos_filename)?;
+    //     let pos: HashMap<String, Vec<ControlCalyxPosInfo>> =
+    //         serde_json::from_reader(BufReader::new(pos_file))?;
+
+    //     Ok(())
+    // }
+}
+
+// #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+// pub struct ControlId(u32);
+// entity_impl!(ControlId, "control");
+
+// #[derive(Debug, Clone)]
+
+// struct Control {
+//     name: String,
+
+//     // probe: SignalRef,
+//     // invokes: SmallVec<[InvokeId; 6]>,
+//     // probe_idx: u32,
+// }

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -142,7 +142,7 @@ impl ControlInfo {
         let mut tdcc_map = FxHashMap::default();
 
         // need to process pos_file first because it gives us the Calyx positions of all control nodes.
-        println!("Parsing {}", pos_filename);
+        eprintln!("Parsing {}", pos_filename);
         let pos_file = File::open(pos_filename)?;
         let pos: HashMap<String, Vec<ControlCalyxPosInfo>> =
             serde_json::from_reader(BufReader::new(pos_file))?;
@@ -153,7 +153,7 @@ impl ControlInfo {
             }
         }
 
-        println!("Parsing {}", tdcc_filename);
+        eprintln!("Parsing {}", tdcc_filename);
         let tdcc_file = File::open(tdcc_filename)?;
         let tdcc_profiling_info: HashSet<ProfilingInfo> =
             serde_json::from_reader(BufReader::new(tdcc_file))?;
@@ -176,29 +176,16 @@ impl ControlInfo {
             }
         }
 
-        println!("Parsing {}", pd_filename);
+        eprintln!("Parsing {}", pd_filename);
         let pd_file = File::open(pd_filename)?;
         let pd: BTreeMap<String, PathDescriptorInfo> =
             serde_json::from_reader(BufReader::new(pd_file))?;
-        // let mut component_to_group_parent = HashMap::new();
-        // let mut component_to_ctrl_stack = HashMap::new();
-        // for (component, comp_pd) in pd {
-        //     let (group_to_parent, control_stack) = sort_path_descriptors(
-        //         comp_pd,
-        //         component_to_controls.get_mut(&component).unwrap(),
-        //     );
-        //     component_to_group_parent
-        //         .insert(component.clone(), group_to_parent);
-        //     component_to_ctrl_stack.insert(component, control_stack);
-        // }
 
         let out = Self {
             tdcc_map,
             pretty_map: pp_name_map,
             pd
         };
-
-        println!("{out:?}");
 
         Ok(out)
     }

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -140,6 +140,13 @@ pub struct Design {
     signals: Vec<SignalRef>,
 }
 
+pub struct CellControl {
+    group_to_parent: FxHashMap<String, Option<ControlId>>,
+    /// The outermost control node, if one exists.
+    /// Will be None when there are no control nodes in the component.
+    toplevel_control: Option<ControlId>,
+}
+
 impl Design {
     pub fn new(h: &wellen::Hierarchy, c: ControlInfo, s: SharedCellsInfo) -> Result<Self> {
         let main = h
@@ -465,12 +472,12 @@ impl Design {
         h: &Hierarchy,
         s: ScopeRef,
         c: &ControlInfo,
-        component: &String,
-    ) -> Result<(FxHashMap<String, Option<ControlId>>, Option<ControlId>)> {
+        component: &str,
+    ) -> Result<CellControl> {
         // Add Control into the tree, and return a map of groups with their control parent,
         // along with the top-level ControlId if one exists.
         // NOTE: If the component has a single-group control, the second entry will be None.
-        let mut toplevel_ctrl = None;
+        let mut toplevel_control = None;
 
         let mut pos_to_id = FxHashMap::default();
         let mut descriptor_to_id: FxHashMap<String, ControlId> =
@@ -481,7 +488,7 @@ impl Design {
 
         // iterate through control par descriptors and construct Control nodes
         for (d, pos_set) in descriptors.control_pos.iter() {
-            let (pretty, pos) = c.get_pretty(&pos_set)?;
+            let (pretty, pos) = c.get_pretty(pos_set)?;
             // any pos without an entry in tdcc was compiled away; we ignore these.
             if let Some(tdcc_info_vec) = c.get_tdcc(pos)? {
                 // pos is the entry to the Calyx-generated position of the control node,
@@ -541,17 +548,17 @@ impl Design {
             if !found {
                 // the only ctrl node without a parent should be the toplevel control node
                 assert_eq!(idx, ctrl_desc_rev_sorted.len() - 1);
-                toplevel_ctrl = Some(ctrl_id);
+                toplevel_control = Some(ctrl_id);
             }
         }
 
-        let out = Self::groups_to_ctrl_parent(
+        let group_to_parent = Self::groups_to_ctrl_parent(
             &descriptor_to_id,
             descriptors,
             &ctrl_desc_rev_sorted,
         );
 
-        Ok((out, toplevel_ctrl))
+        Ok(CellControl {group_to_parent, toplevel_control })
     }
 
     fn groups_to_ctrl_parent(
@@ -622,9 +629,9 @@ impl Design {
     ) -> Result<()> {
         let component = get_component(h, cell_scope)?;
         cell.component = component.to_string();
-        let (group_to_ctrl_parent, top_ctrl_opt) =
-            self.populate_control(h, cell_scope, c, &component.to_string())?;
-        if let Some(top_ctrl) = top_ctrl_opt {
+        let CellControl { group_to_parent, toplevel_control} =
+            self.populate_control(h, cell_scope, c, component)?;
+        if let Some(top_ctrl) = toplevel_control {
             cell.control.push(top_ctrl);
         }
 
@@ -735,7 +742,7 @@ impl Design {
                                 probe_idx: u32::MAX,
                             });
                             if let Some(Some(ctrl_parent)) =
-                                group_to_ctrl_parent.get(&name)
+                                group_to_parent.get(&name)
                             {
                                 let invokeid = self.invokes.push(Invoke {
                                     _name: name,
@@ -847,15 +854,14 @@ pub fn get_component(h: &Hierarchy, cell_scope: ScopeRef) -> Result<&str> {
     // brute-force hack to grab the name of the cell's component before computing control.
     let probe_scope = h[cell_scope]
         .scopes(h)
-        .filter(|s| h[*s].name(h).ends_with("_probe"))
-        .next()
+        .find(|s| h[*s].name(h).ends_with("_probe"))
         .unwrap();
     let name = h[probe_scope].name(h);
     match parse_probe_name(name)? {
         ProbeName::Group { component, .. }
         | ProbeName::InvokePrimitive { component, .. }
         | ProbeName::InvokeCell { component, .. }
-        | ProbeName::InvokeGroup { component, .. } => return Ok(component),
+        | ProbeName::InvokeGroup { component, .. } => Ok(component),
     }
 }
 

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -272,6 +272,7 @@ impl Design {
             }
         }
 
+        // either a group or a control must have been active this cycle.
         assert!(!out.is_empty());
 
         out
@@ -456,7 +457,6 @@ impl Design {
         c: &ControlInfo,
         component: &String,
     ) -> Result<(FxHashMap<String, Option<ControlId>>, Option<ControlId>)> {
-        println!("component name: {component}");
         // Add Control into the tree, and return a map of groups with their control parent,
         // along with the top-level ControlId if one exists.
         // NOTE: If the component has a single-group control, the second entry will be None.
@@ -508,7 +508,7 @@ impl Design {
             let control = self.controls.get(ctrl_id).unwrap();
             let mut found = false;
             let mut i = idx + 1;
-            while i < ctrl_desc_rev_sorted.len() - 1 {
+            while i < ctrl_desc_rev_sorted.len() {
                 let &maybe_parent = ctrl_desc_rev_sorted.get(i).unwrap();
                 if desc.starts_with(maybe_parent) {
                     // maybe_parent --> desc invoke

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -152,7 +152,11 @@ pub struct Design {
 }
 
 impl Design {
-    pub fn new(h: &wellen::Hierarchy, c: ControlInfo, s: SharedCellsInfo) -> Result<Self> {
+    pub fn new(
+        h: &wellen::Hierarchy,
+        c: ControlInfo,
+        s: SharedCellsInfo,
+    ) -> Result<Self> {
         let main = h
             .lookup_scope(&[&"toplevel", &"main"])
             .with_context(|| "Failed to find main scope")?;
@@ -561,7 +565,10 @@ impl Design {
             &ctrl_desc_rev_sorted,
         );
 
-        Ok(CellControl {group_to_parent, toplevel_control })
+        Ok(CellControl {
+            group_to_parent,
+            toplevel_control,
+        })
     }
 
     /// Helper function that returns a map from groups to their control parent in the tree.
@@ -634,8 +641,10 @@ impl Design {
         // Create control nodes and add an edge from a cell to the toplevel control.
         let component = get_component(h, cell_scope)?;
         cell.component = component.to_string();
-        let CellControl { group_to_parent, toplevel_control} =
-            self.populate_control(h, cell_scope, c, component)?;
+        let CellControl {
+            group_to_parent,
+            toplevel_control,
+        } = self.populate_control(h, cell_scope, c, component)?;
         if let Some(top_ctrl) = toplevel_control {
             cell.control.push(top_ctrl);
         }
@@ -718,7 +727,10 @@ impl Design {
         // iterate through all probes in this scope. Structural enable probes will be ignored as nodes for them were previously created.
         for probe_scope in h[cell_scope].scopes(h) {
             let name = h[probe_scope].name(h);
-            if name.ends_with("_probe") && !name.ends_with("_contprimitive_probe"){ // ignore continuous primitives for now
+            if name.ends_with("_probe")
+                && !name.ends_with("_contprimitive_probe")
+            {
+                // ignore continuous primitives for now
                 let out = get_var(h, &h[probe_scope], "out")?;
                 let probe = h[out].signal_ref();
                 let probe_name = parse_probe_name(name)?;
@@ -799,8 +811,13 @@ impl Design {
                             // TODO: Primitives would not have a scope if they are shared.
                             let scope = get_scope(h, &h[cell_scope], name).ok();
                             let replacement = if scope.is_none() {
-                                s.get_replacement(component.to_string(), name.to_string())
-                            } else { None };
+                                s.get_replacement(
+                                    component.to_string(),
+                                    name.to_string(),
+                                )
+                            } else {
+                                None
+                            };
                             let mut cell_instance = Cell {
                                 name: name.to_string(),
                                 groups: smallvec![],
@@ -811,7 +828,7 @@ impl Design {
                                 component: String::new(),
                                 probes: None,
                                 probe_idxs: None,
-                                replacement
+                                replacement,
                             };
                             if !is_primitive {
                                 assert!(scope.is_some());
@@ -820,7 +837,7 @@ impl Design {
                                     scope.unwrap(),
                                     &mut cell_instance,
                                     c,
-                                    s
+                                    s,
                                 )?;
                             }
                             let cell_id = self.cells.push(cell_instance);

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use core::panic;
 
 use baa::{BitVecOps, BitVecValue};
@@ -272,8 +272,11 @@ impl Design {
             }
         }
 
-        // either a group or a control must have been active this cycle.
-        assert!(!out.is_empty());
+        // Edge case: if the cell is static, there could be cycles where
+        // no group or control is active!
+        if (out.is_empty()) {
+            out.push(prefix);
+        }
 
         out
     }
@@ -607,8 +610,9 @@ impl Design {
         cell: &mut Cell,
         c: &ControlInfo,
     ) -> Result<()> {
+        let component = get_component(h, cell_scope)?;
         let (group_to_ctrl_parent, top_ctrl_opt) =
-            self.populate_control(h, cell_scope, c, &cell.name)?;
+            self.populate_control(h, cell_scope, c, &component.to_string())?;
         if let Some(top_ctrl) = top_ctrl_opt {
             cell.control.push(top_ctrl);
         }
@@ -818,6 +822,20 @@ impl Design {
         }
         assert!(parentless_invokes.is_empty());
         Ok(())
+    }
+
+}
+
+pub fn get_component(h: &Hierarchy, cell_scope: ScopeRef) -> Result<&str> {
+    // brute-force hack to grab the name of the cell's component before computing control.
+    let probe_scope = h[cell_scope].scopes(h).filter(|s| h[*s].name(h).ends_with("_probe")).next().unwrap();
+    let name = h[probe_scope].name(h);
+    match parse_probe_name(name)? {
+        ProbeName::Group { component, .. } | ProbeName::InvokePrimitive { component, .. } |
+        ProbeName::InvokeCell { component, .. } |
+        ProbeName::InvokeGroup { component, .. } => {
+            return Ok(component)
+        }
     }
 }
 

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -250,7 +250,7 @@ impl Design {
                 return vec![prefix];
             }
         }
-        if cell.groups.is_empty() {
+        if cell.groups.is_empty() && cell.control.is_empty() {
             // No more children, so this is a sink.
             return vec![prefix];
         }
@@ -263,9 +263,70 @@ impl Design {
                 out.append(&mut group_stacks);
             }
         }
-        // if the cell has groups but none of them are active, we still need to add the cell
+        for &control_idx in &cell.control {
+            let control = &self.controls[control_idx];
+            if value.is_bit_set(control.go_idx) {
+                let mut control_stacks =
+                    self.compute_control(value, control_idx, prefix.clone());
+                out.append(&mut control_stacks);
+            }
+        }
+
+        assert!(!out.is_empty());
+
+        out
+    }
+
+    /// Builds up all active tree paths this cycle from the group of group_id.
+    /// prefix is the state of the stack before this particular group.
+    /// NOTE: This function is co-recursive with compute_cell(), and only called when
+    /// the control group is active (otherwise this function would not be called.)
+    fn compute_control(
+        &self,
+        value: &BitVecValue,
+        control_id: ControlId,
+        mut prefix: Stack,
+    ) -> Vec<Stack> {
+        let control = &self.controls[control_id];
+        prefix.push(control.display_name());
+        if control.invokes.is_empty() {
+            return vec![prefix];
+        }
+        let mut out = vec![];
+        for &invoke_id in &control.invokes {
+            let mut this_thread_prefix = prefix.clone();
+            let invoke = &self.invokes[invoke_id];
+            if value.is_bit_set(invoke.probe_idx) {
+                match invoke.target {
+                    InvokeTarget::Cell(_) => {
+                        panic!(
+                            "Control node {} directly invokes cell (control nodes should only invoke control nodes and groups)",
+                            control.name
+                        )
+                    }
+                    InvokeTarget::Group(target_group_id) => {
+                        let mut group_stacks = self.compute_group(
+                            value,
+                            target_group_id,
+                            prefix.clone(),
+                        );
+                        out.append(&mut group_stacks);
+                    }
+                    InvokeTarget::Control(target_control_id) => {
+                        let mut control_stacks = self.compute_control(
+                            value,
+                            target_control_id,
+                            prefix.clone(),
+                        );
+                        out.append(&mut control_stacks);
+                    }
+                }
+            }
+        }
+        // if the control node invokes control nodes/groups but none of them are active,
+        // we still need to add the control node.
         // NOTE: this would be a control cycle.
-        if !cell.groups.is_empty() && out.is_empty() {
+        if !control.invokes.is_empty() && out.is_empty() {
             out.push(prefix);
         }
 
@@ -274,7 +335,7 @@ impl Design {
 
     /// Builds up all active tree paths this cycle from the group of group_id.
     /// prefix is the state of the stack before this particular group.
-    /// NOTE: This function is co-recursive with compute_cell(), and only called when
+    /// NOTE: This function is co-recursive with compute_cell() and compute_control(), and only called when
     /// the group is active (otherwise this function would not be called.)
     fn compute_group(
         &self,
@@ -413,11 +474,13 @@ impl Design {
             let (pretty, pos) = c.get_pretty(&pos_set)?;
             // any pos without an entry in tdcc was compiled away; we ignore these.
             if let Some(tdcc_info_vec) = c.get_tdcc(pos)? {
+                // pos is the entry to the Calyx-generated position of the control node,
+                // so there should only be one entry in the Vector.
                 assert_eq!(tdcc_info_vec.len(), 1);
                 let name = tdcc_info_vec.iter().next().unwrap().name.clone();
 
-                let ctrl_scope = get_scope(h, &h[s], &name)?;
-                let go_ref = get_var(h, &h[ctrl_scope], "go")?;
+                let ctrl_scope = get_scope(h, &h[s], &format!("{name}_go"))?;
+                let go_ref = get_var(h, &h[ctrl_scope], "out")?;
                 let go = h[go_ref].signal_ref();
 
                 let ctrl = Control {

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use core::panic;
 
 use baa::{BitVecOps, BitVecValue};
@@ -8,6 +8,7 @@ use smallvec::{SmallVec, smallvec};
 use wellen::{Hierarchy, Scope, ScopeRef, SignalRef, VarRef};
 
 use crate::control::{ControlInfo, PathDescriptorInfo};
+use crate::shared_cells::SharedCellsInfo;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct CellId(u32);
@@ -25,7 +26,7 @@ struct Cell {
     /// NOTE: Primitive cells should have an empty vec here.
     groups: SmallVec<[GroupId; 6]>,
     /// The scope of the cell in the RTL trace.
-    _scope: ScopeRef,
+    _scope: Option<ScopeRef>,
     /// Is the cell a primitive?
     is_primitive: bool,
     /// If the cell is of the main component, contains a ref to main.go and main.done.
@@ -37,13 +38,20 @@ struct Cell {
     component: String,
     /// cells that are defined within the component
     instances: SmallVec<[CellId; 6]>,
+    /// Name of the replacement cell, if the cell was a shared primitive.
+    replacement: Option<String>,
 }
 
 impl Cell {
     /// String representation of cell for trace and visualizations
     pub fn display_name(&self) -> String {
         if self.is_primitive {
-            format!("{} (primitive)", self.name)
+            let s = format!("{} (primitive)", self.name);
+            if let Some(r) = &self.replacement {
+                format!("{s} -> {}", r)
+            } else {
+                s
+            }
         } else if self.component == "main" {
             self.name.clone()
         } else {
@@ -84,7 +92,7 @@ struct Control {
     go: SignalRef,
     invokes: SmallVec<[InvokeId; 6]>,
     go_idx: u32,
-    pos: u32,
+    _pos: u32,
     pretty: String,
     // deal with registers later
 }
@@ -133,7 +141,7 @@ pub struct Design {
 }
 
 impl Design {
-    pub fn new(h: &wellen::Hierarchy, c: ControlInfo) -> Result<Self> {
+    pub fn new(h: &wellen::Hierarchy, c: ControlInfo, s: SharedCellsInfo) -> Result<Self> {
         let main = h
             .lookup_scope(&[&"toplevel", &"main"])
             .with_context(|| "Failed to find main scope")?;
@@ -148,7 +156,7 @@ impl Design {
             clk,
             signals: vec![],
         };
-        out.populate(h, c)?;
+        out.populate(h, c, s)?;
         out.build_idx();
         Ok(out)
     }
@@ -274,7 +282,7 @@ impl Design {
 
         // Edge case: if the cell is static, there could be cycles where
         // no group or control is active!
-        if (out.is_empty()) {
+        if out.is_empty() {
             out.push(prefix);
         }
 
@@ -298,7 +306,6 @@ impl Design {
         }
         let mut out = vec![];
         for &invoke_id in &control.invokes {
-            let mut this_thread_prefix = prefix.clone();
             let invoke = &self.invokes[invoke_id];
             if value.is_bit_set(invoke.probe_idx) {
                 match invoke.target {
@@ -491,7 +498,7 @@ impl Design {
                     go,
                     invokes: smallvec![],
                     go_idx: u32::MAX,
-                    pos,
+                    _pos: pos,
                     pretty,
                 };
                 let ctrl_id = self.controls.push(ctrl);
@@ -579,6 +586,7 @@ impl Design {
         &mut self,
         h: &wellen::Hierarchy,
         c: ControlInfo,
+        s: SharedCellsInfo,
     ) -> Result<()> {
         let main_scope = h
             .lookup_scope(&[&"toplevel", &"main"])
@@ -590,14 +598,15 @@ impl Design {
             control: smallvec![],
             groups: smallvec![],
             probes: Some((h[main_go].signal_ref(), h[main_done].signal_ref())),
-            _scope: main_scope,
+            _scope: Some(main_scope),
             is_primitive: false,
             instances: smallvec![],
             component: String::new(),
             probe_idxs: None,
+            replacement: None,
         };
         // add control nodes for main
-        self.scan_probes(h, main_scope, &mut main_cell, &c)?;
+        self.scan_probes(h, main_scope, &mut main_cell, &c, &s)?;
         self.main = self.cells.push(main_cell);
         Ok(())
     }
@@ -609,8 +618,10 @@ impl Design {
         cell_scope: ScopeRef,
         cell: &mut Cell,
         c: &ControlInfo,
+        s: &SharedCellsInfo,
     ) -> Result<()> {
         let component = get_component(h, cell_scope)?;
+        cell.component = component.to_string();
         let (group_to_ctrl_parent, top_ctrl_opt) =
             self.populate_control(h, cell_scope, c, &component.to_string())?;
         if let Some(top_ctrl) = top_ctrl_opt {
@@ -695,7 +706,7 @@ impl Design {
         // iterate through all probes in this scope. Structural enable probes will be ignored as nodes for them were previously created.
         for probe_scope in h[cell_scope].scopes(h) {
             let name = h[probe_scope].name(h);
-            if name.ends_with("_probe") {
+            if name.ends_with("_probe") && !name.ends_with("_contprimitive_probe"){ // ignore continuous primitives for now
                 let out = get_var(h, &h[probe_scope], "out")?;
                 let probe = h[out].signal_ref();
                 let probe_name = parse_probe_name(name)?;
@@ -773,7 +784,11 @@ impl Design {
                         let target = if let Some(&t) = maybe_target {
                             t
                         } else {
-                            let scope = get_scope(h, &h[cell_scope], name)?;
+                            // TODO: Primitives would not have a scope if they are shared.
+                            let scope = get_scope(h, &h[cell_scope], name).ok();
+                            let replacement = if scope.is_none() {
+                                s.get_replacement(component.to_string(), name.to_string())
+                            } else { None };
                             let mut cell_instance = Cell {
                                 name: name.to_string(),
                                 groups: smallvec![],
@@ -784,13 +799,16 @@ impl Design {
                                 component: String::new(),
                                 probes: None,
                                 probe_idxs: None,
+                                replacement
                             };
                             if !is_primitive {
+                                assert!(scope.is_some());
                                 self.scan_probes(
                                     h,
-                                    scope,
+                                    scope.unwrap(),
                                     &mut cell_instance,
                                     c,
+                                    s
                                 )?;
                             }
                             let cell_id = self.cells.push(cell_instance);
@@ -823,19 +841,21 @@ impl Design {
         assert!(parentless_invokes.is_empty());
         Ok(())
     }
-
 }
 
 pub fn get_component(h: &Hierarchy, cell_scope: ScopeRef) -> Result<&str> {
     // brute-force hack to grab the name of the cell's component before computing control.
-    let probe_scope = h[cell_scope].scopes(h).filter(|s| h[*s].name(h).ends_with("_probe")).next().unwrap();
+    let probe_scope = h[cell_scope]
+        .scopes(h)
+        .filter(|s| h[*s].name(h).ends_with("_probe"))
+        .next()
+        .unwrap();
     let name = h[probe_scope].name(h);
     match parse_probe_name(name)? {
-        ProbeName::Group { component, .. } | ProbeName::InvokePrimitive { component, .. } |
-        ProbeName::InvokeCell { component, .. } |
-        ProbeName::InvokeGroup { component, .. } => {
-            return Ok(component)
-        }
+        ProbeName::Group { component, .. }
+        | ProbeName::InvokePrimitive { component, .. }
+        | ProbeName::InvokeCell { component, .. }
+        | ProbeName::InvokeGroup { component, .. } => return Ok(component),
     }
 }
 

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -6,6 +6,8 @@ use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec};
 use wellen::{Hierarchy, Scope, ScopeRef, SignalRef, VarRef};
 
+use crate::control::AllControl;
+
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct CellId(u32);
 entity_impl!(CellId, "cell");
@@ -15,6 +17,9 @@ entity_impl!(CellId, "cell");
 struct Cell {
     /// The user-defined name of the cell.
     name: String,
+    /// Ids of control nodes that could be called from this cell, if it is a component.
+    /// NOTE: Primitive cells should have an empty vec here.
+    control: SmallVec<[ControlId; 6]>,
     /// Ids of groups that could be called from this cell, if it is a component.
     /// NOTE: Primitive cells should have an empty vec here.
     groups: SmallVec<[GroupId; 6]>,
@@ -68,6 +73,32 @@ impl Group {
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+pub struct ControlId(u32);
+entity_impl!(ControlId, "control");
+
+#[derive(Debug, Clone)]
+/// Represents a control activation from a component.
+struct Control {
+    name: String,
+    probe: SignalRef,
+    invokes: SmallVec<[InvokeId; 6]>,
+    probe_idx: u32,
+    // deal with registers later?
+    pos: u32,
+    line_num: u32,
+    control_type: String,
+}
+
+impl Control {
+    pub fn display_name(&self) -> String {
+        format!(
+            "{} ~ L{}:{} (ctrl)",
+            self.name, self.line_num, self.control_type
+        )
+    }
+}
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct InvokeId(u32);
 entity_impl!(InvokeId, "invoke");
 
@@ -82,12 +113,14 @@ struct Invoke {
 }
 
 #[derive(Debug, Clone)]
-/// Represents a target of an invoke from a group
+/// Represents a target of an invoke from a group/control node
 enum InvokeTarget {
     // Group invokes a component/primitive cell
     Cell(CellId),
-    // Group invokes a group (structural enable)
+    // Control/Group invokes a group (structural enable)
     Group(GroupId),
+    // // Control invokes a control
+    // Control(ControlId),
 }
 
 #[derive(Clone, Debug)]
@@ -98,13 +131,14 @@ pub struct Design {
     /// NOTE: Does not include groups that are activated via structural enables.
     groups: PrimaryMap<GroupId, Group>,
     invokes: PrimaryMap<InvokeId, Invoke>,
+    control: PrimaryMap<ControlId, Control>,
     main: CellId,
     clk: SignalRef,
     signals: Vec<SignalRef>,
 }
 
 impl Design {
-    pub fn new(h: &wellen::Hierarchy) -> Result<Self> {
+    pub fn new(h: &wellen::Hierarchy, c: AllControl) -> Result<Self> {
         let main = h
             .lookup_scope(&[&"toplevel", &"main"])
             .with_context(|| "Failed to find main scope")?;
@@ -114,11 +148,13 @@ impl Design {
             cells: PrimaryMap::new(),
             groups: PrimaryMap::new(),
             invokes: PrimaryMap::new(),
+            control: PrimaryMap::new(),
             main: CellId(u32::MAX),
             clk,
             signals: vec![],
         };
-        out.populate(h)?;
+
+        out.populate(h, c)?;
         out.build_idx();
         Ok(out)
     }
@@ -348,7 +384,7 @@ impl Design {
     }
 
     /// Builds the static call tree by scanning through all probes to find tree edges.
-    fn populate(&mut self, h: &wellen::Hierarchy) -> Result<()> {
+    fn populate(&mut self, h: &wellen::Hierarchy, c: AllControl) -> Result<()> {
         let main_scope = h
             .lookup_scope(&[&"toplevel", &"main"])
             .with_context(|| "Failed to find main scope")?;
@@ -356,6 +392,7 @@ impl Design {
         let main_done = get_var(h, &h[main_scope], "done")?;
         let mut main_cell = Cell {
             name: "main".to_string(),
+            control: smallvec![],
             groups: smallvec![],
             probes: Some((h[main_go].signal_ref(), h[main_done].signal_ref())),
             _scope: main_scope,
@@ -364,6 +401,8 @@ impl Design {
             component: String::new(),
             probe_idxs: None,
         };
+        // add control nodes for main
+
         self.scan_probes(h, main_scope, &mut main_cell)?;
         self.main = self.cells.push(main_cell);
         Ok(())
@@ -522,6 +561,7 @@ impl Design {
                             let mut cell_instance = Cell {
                                 name: name.to_string(),
                                 groups: smallvec![],
+                                control: smallvec![],
                                 _scope: scope,
                                 is_primitive,
                                 instances: smallvec![],

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -128,6 +128,17 @@ enum InvokeTarget {
     Control(ControlId),
 }
 
+#[derive(Debug, Clone)]
+/// Information necessary to "stitch" Control nodes in the appropriate spot within a Cell.
+pub struct CellControl {
+    /// Map from group to their Control parent (so we know where in the tree to add groups to.)
+    group_to_parent: FxHashMap<String, Option<ControlId>>,
+    /// The outermost control node, if one exists.
+    /// Will be None when there are no control nodes in the component.
+    /// (ex. a component with a single-group control)
+    toplevel_control: Option<ControlId>,
+}
+
 #[derive(Clone, Debug)]
 /// Represents the static call tree (all possible calls).
 pub struct Design {
@@ -138,13 +149,6 @@ pub struct Design {
     main: CellId,
     clk: SignalRef,
     signals: Vec<SignalRef>,
-}
-
-pub struct CellControl {
-    group_to_parent: FxHashMap<String, Option<ControlId>>,
-    /// The outermost control node, if one exists.
-    /// Will be None when there are no control nodes in the component.
-    toplevel_control: Option<ControlId>,
 }
 
 impl Design {
@@ -467,6 +471,8 @@ impl Design {
         signals
     }
 
+    /// Construct control nodes and the edges between them, and returns information necessary
+    /// to "stitch" the control nodes into the tree.
     fn populate_control(
         &mut self,
         h: &Hierarchy,
@@ -474,9 +480,6 @@ impl Design {
         c: &ControlInfo,
         component: &str,
     ) -> Result<CellControl> {
-        // Add Control into the tree, and return a map of groups with their control parent,
-        // along with the top-level ControlId if one exists.
-        // NOTE: If the component has a single-group control, the second entry will be None.
         let mut toplevel_control = None;
 
         let mut pos_to_id = FxHashMap::default();
@@ -561,6 +564,7 @@ impl Design {
         Ok(CellControl {group_to_parent, toplevel_control })
     }
 
+    /// Helper function that returns a map from groups to their control parent in the tree.
     fn groups_to_ctrl_parent(
         descriptor_to_id: &FxHashMap<String, ControlId>,
         descriptors: &PathDescriptorInfo,
@@ -627,6 +631,7 @@ impl Design {
         c: &ControlInfo,
         s: &SharedCellsInfo,
     ) -> Result<()> {
+        // Create control nodes and add an edge from a cell to the toplevel control.
         let component = get_component(h, cell_scope)?;
         cell.component = component.to_string();
         let CellControl { group_to_parent, toplevel_control} =
@@ -677,16 +682,16 @@ impl Design {
                                 })
                                 .map(|(_, ii)| ii)
                                 .collect();
-                            let groupid = self.groups.push(Group {
+                            let group_id = self.groups.push(Group {
                                 name: name.to_string(),
                                 probe,
                                 invokes,
                                 probe_idx: u32::MAX,
                             });
-                            all_groups.push(groupid);
+                            all_groups.push(group_id);
                             structurally_invoked_group_names
                                 .push(name.to_string());
-                            groupid
+                            group_id
                         };
                         let invoke_id = self.invokes.push(Invoke {
                             _name: name.to_string(),
@@ -850,8 +855,9 @@ impl Design {
     }
 }
 
+/// Called to grab the name of the cell's component before computing control.
 pub fn get_component(h: &Hierarchy, cell_scope: ScopeRef) -> Result<&str> {
-    // brute-force hack to grab the name of the cell's component before computing control.
+    // brute-force approach: Grab a probe signal in the cell's scope, parse and return the component name.
     let probe_scope = h[cell_scope]
         .scopes(h)
         .find(|s| h[*s].name(h).ends_with("_probe"))

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -1,14 +1,15 @@
-use core::panic;
-
 use anyhow::{Context, Result};
+use core::panic;
+use std::collections::HashMap;
 
 use baa::{BitVecOps, BitVecValue};
 use cranelift_entity::{PrimaryMap, entity_impl};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use smallvec::{SmallVec, smallvec};
 use wellen::{Hierarchy, Scope, ScopeRef, SignalRef, VarRef};
 
-use crate::control::AllControl;
+use crate::control::{AllControl, ControlInfo, PathDescriptorInfo};
+use crate::design::InvokeTarget::{Control, Group};
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct CellId(u32);
@@ -85,18 +86,14 @@ struct Control {
     go: SignalRef,
     invokes: SmallVec<[InvokeId; 6]>,
     go_idx: u32,
-    // deal with registers later?
     pos: u32,
-    line_num: u32,
-    control_type: String,
+    pretty: String,
+    // deal with registers later
 }
 
 impl Control {
     pub fn display_name(&self) -> String {
-        format!(
-            "{} ~ L{}:{} (ctrl)",
-            self.name, self.line_num, self.control_type
-        )
+        format!("{} ~ {} (ctrl)", self.name, self.pretty)
     }
 }
 
@@ -138,7 +135,7 @@ pub struct Design {
 }
 
 impl Design {
-    pub fn new(h: &wellen::Hierarchy, c: AllControl) -> Result<Self> {
+    pub fn new(h: &wellen::Hierarchy, c: ControlInfo) -> Result<Self> {
         let main = h
             .lookup_scope(&[&"toplevel", &"main"])
             .with_context(|| "Failed to find main scope")?;
@@ -153,7 +150,6 @@ impl Design {
             clk,
             signals: vec![],
         };
-
         out.populate(h, c)?;
         out.build_idx();
         Ok(out)
@@ -324,6 +320,7 @@ impl Design {
                         );
                         out.append(&mut group_stacks);
                     }
+                    InvokeTarget::Control(_) => {panic!("Group should not invoke a Control node!")}
                 }
             }
         }
@@ -387,33 +384,123 @@ impl Design {
         &mut self,
         h: &Hierarchy,
         s: ScopeRef,
-        c: AllControl,
+        c: ControlInfo,
         component: String,
-    ) -> Result<()> {
-        if let Some(ctrl_stack) = c.component_to_ctrl_stack.get(&component) {
-            let component_meta_info = c.component_to_controls.get(&component).unwrap();
+    ) -> Result<(FxHashMap<String, Option<ControlId>>, Option<ControlId>)> {
+        // Add Control into the tree, and return a map of groups with their control parent,
+        // along with the top-level ControlId if one exists.
+        // NOTE: If the component has a single-group control, the second entry will be None.
+        let mut toplevel_ctrl = None;
 
-            for ctrl_pos in ctrl_stack {
-                let meta_info = component_meta_info.get(ctrl_pos).unwrap();
-                let ctrl_group_scope = get_scope(h, &h[s], &meta_info.name)?;
-                let ctrl_group_go = get_var(h, &h[ctrl_group_scope], "go")?;
-                // create Control node
-                let ctrl_node = Control {
-                    name: "".to_string(),
-                    go: h[ctrl_group_go].signal_ref(),
-                    invokes: Default::default(),
-                    go_idx: u32::MAX,
-                    pos: 0,
-                    line_num: 0,
-                    control_type: "".to_string(),
-                };
+        let mut pos_to_id = FxHashMap::default();
+        let mut descriptor_to_id: FxHashMap<String, ControlId> =
+            FxHashMap::default();
+
+        let descriptors = c.descriptors(&component);
+        // let ctrl_map = descriptors.control_pos;
+
+        // iterate through control par descriptors and construct Control nodes
+        for (d, pos_set) in descriptors.control_pos.iter() {
+            let (pretty, pos) = c.get_pretty(&pos_set)?;
+            let tdcc_info_vec = c.get_tdcc(pos)?;
+            assert_eq!(tdcc_info_vec.len(), 1);
+            let name = tdcc_info_vec.iter().next().unwrap().name.clone();
+
+            let ctrl_scope = get_scope(h, &h[s], &name)?;
+            let go_ref = get_var(h, &h[ctrl_scope], "go")?;
+            let go = h[go_ref].signal_ref();
+
+            let ctrl = Control {
+                name,
+                go,
+                invokes: smallvec![],
+                go_idx: u32::MAX,
+                pos,
+                pretty,
+            };
+            let ctrl_id = self.controls.push(ctrl);
+            pos_to_id.insert(pos, ctrl_id);
+            descriptor_to_id.insert(d, ctrl_id);
+        }
+
+        // compute groups' parent info (reverse sort for easier checking)
+        let mut ctrl_desc_rev_sorted =
+            descriptors.control_pos.keys().collect::<Vec<_>>();
+        ctrl_desc_rev_sorted.sort();
+        ctrl_desc_rev_sorted.reverse();
+
+        for (idx, desc) in ctrl_desc_rev_sorted.iter().enumerate() {
+            let ctrl_id = descriptor_to_id[*desc];
+            let control = self.controls[ctrl_id];
+            let mut found = false;
+            let mut i = idx + 1;
+            while i < ctrl_desc_rev_sorted.len() - 1 {
+                let &maybe_parent = ctrl_desc_rev_sorted.get(i).unwrap();
+                if desc.starts_with(maybe_parent) {
+                    // maybe_parent --> desc invoke
+                    let invoke = Invoke {
+                        _name: control.name,
+                        probe: control.go,
+                        target: Control(ctrl_id),
+                        probe_idx: u32::MAX,
+                    };
+                    let invoke_id = self.invokes.push(invoke);
+                    let parent_ctrl_id = descriptor_to_id[maybe_parent];
+                    let parent_ctrl = self.controls[parent_ctrl_id];
+                    parent_ctrl.invokes.push(invoke_id);
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                // the only ctrl node without a parent should be the toplevel control node
+                assert_eq!(idx, ctrl_desc_rev_sorted.len() - 1);
+                toplevel_ctrl = Some(ctrl_id);
             }
         }
-        Ok(())
+
+        let out = Self::groups_to_ctrl_parent(
+            &mut descriptor_to_id,
+            descriptors,
+            &mut ctrl_desc_rev_sorted,
+        );
+
+        Ok((out, toplevel_ctrl))
+    }
+
+    fn groups_to_ctrl_parent(
+        descriptor_to_id: &FxHashMap<String, ControlId>,
+        descriptors: &PathDescriptorInfo,
+        ctrl_desc_sorted: &mut Vec<&String>,
+    ) -> FxHashMap<String, Option<ControlId>> {
+        let mut out: FxHashMap<String, Option<ControlId>> =
+            FxHashMap::default();
+        for (g, d) in descriptors.enables.iter() {
+            // find the immediate control node parent
+            let mut found = false;
+            for &cd in ctrl_desc_sorted.iter() {
+                if d.starts_with(cd) {
+                    out.insert(
+                        g.clone(),
+                        Some(*descriptor_to_id.get(cd).unwrap()),
+                    );
+                    found = true;
+                    break; // breaking because we found the first match
+                }
+            }
+            if !found {
+                out.insert(g.clone(), None);
+            }
+        }
+        out
     }
 
     /// Builds the static call tree by scanning through all probes to find tree edges.
-    fn populate(&mut self, h: &wellen::Hierarchy, c: AllControl) -> Result<()> {
+    fn populate(
+        &mut self,
+        h: &wellen::Hierarchy,
+        c: ControlInfo,
+    ) -> Result<()> {
         let main_scope = h
             .lookup_scope(&[&"toplevel", &"main"])
             .with_context(|| "Failed to find main scope")?;
@@ -431,7 +518,6 @@ impl Design {
             probe_idxs: None,
         };
         // add control nodes for main
-
         self.scan_probes(h, main_scope, &mut main_cell)?;
         self.main = self.cells.push(main_cell);
         Ok(())
@@ -443,7 +529,14 @@ impl Design {
         h: &Hierarchy,
         cell_scope: ScopeRef,
         cell: &mut Cell,
+        c: ControlInfo,
     ) -> Result<()> {
+        let (group_to_ctrl_parent, top_ctrl_opt) =
+            self.populate_control(h, cell_scope, c, cell.name)?;
+        if let Some(top_ctrl) = top_ctrl_opt {
+            cell.control.push(top_ctrl);
+        }
+
         // cell.groups should not contain any structurally enabled groups.
         // So, we will record all names of structurally invoked groups so later we can prevent cell.groups from
         // containing any groups with such names.
@@ -550,7 +643,21 @@ impl Design {
                                 invokes,
                                 probe_idx: u32::MAX,
                             });
-                            cell.groups.push(groupid);
+                            if let Some(Some(ctrl_parent)) =
+                                group_to_ctrl_parent.get(&name)
+                            {
+                                let invokeid = self.invokes.push(Invoke {
+                                    _name: name,
+                                    probe,
+                                    target: Group(groupid),
+                                    probe_idx: u32::MAX,
+                                });
+                                self.controls[*ctrl_parent]
+                                    .invokes
+                                    .push(invokeid);
+                            } else {
+                                cell.groups.push(groupid);
+                            }
                             all_groups.push(groupid);
                         }
                     }

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -1,3 +1,5 @@
+use core::panic;
+
 use anyhow::{Context, Result};
 
 use baa::{BitVecOps, BitVecValue};
@@ -80,9 +82,9 @@ entity_impl!(ControlId, "control");
 /// Represents a control activation from a component.
 struct Control {
     name: String,
-    probe: SignalRef,
+    go: SignalRef,
     invokes: SmallVec<[InvokeId; 6]>,
-    probe_idx: u32,
+    go_idx: u32,
     // deal with registers later?
     pos: u32,
     line_num: u32,
@@ -119,19 +121,17 @@ enum InvokeTarget {
     Cell(CellId),
     // Control/Group invokes a group (structural enable)
     Group(GroupId),
-    // // Control invokes a control
-    // Control(ControlId),
+    // Control invokes a control
+    Control(ControlId),
 }
 
 #[derive(Clone, Debug)]
 /// Represents the static call tree (all possible calls).
 pub struct Design {
     cells: PrimaryMap<CellId, Cell>,
-    /// groups that are activated from control
-    /// NOTE: Does not include groups that are activated via structural enables.
+    controls: PrimaryMap<ControlId, Control>,
     groups: PrimaryMap<GroupId, Group>,
     invokes: PrimaryMap<InvokeId, Invoke>,
-    control: PrimaryMap<ControlId, Control>,
     main: CellId,
     clk: SignalRef,
     signals: Vec<SignalRef>,
@@ -148,7 +148,7 @@ impl Design {
             cells: PrimaryMap::new(),
             groups: PrimaryMap::new(),
             invokes: PrimaryMap::new(),
-            control: PrimaryMap::new(),
+            controls: PrimaryMap::new(),
             main: CellId(u32::MAX),
             clk,
             signals: vec![],
@@ -381,6 +381,35 @@ impl Design {
         signals.sort();
         signals.dedup();
         signals
+    }
+
+    fn populate_control(
+        &mut self,
+        h: &Hierarchy,
+        s: ScopeRef,
+        c: AllControl,
+        component: String,
+    ) -> Result<()> {
+        if let Some(ctrl_stack) = c.component_to_ctrl_stack.get(&component) {
+            let component_meta_info = c.component_to_controls.get(&component).unwrap();
+
+            for ctrl_pos in ctrl_stack {
+                let meta_info = component_meta_info.get(ctrl_pos).unwrap();
+                let ctrl_group_scope = get_scope(h, &h[s], &meta_info.name)?;
+                let ctrl_group_go = get_var(h, &h[ctrl_group_scope], "go")?;
+                // create Control node
+                let ctrl_node = Control {
+                    name: "".to_string(),
+                    go: h[ctrl_group_go].signal_ref(),
+                    invokes: Default::default(),
+                    go_idx: u32::MAX,
+                    pos: 0,
+                    line_num: 0,
+                    control_type: "".to_string(),
+                };
+            }
+        }
+        Ok(())
     }
 
     /// Builds the static call tree by scanning through all probes to find tree edges.

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -1,15 +1,13 @@
 use anyhow::{Context, Result};
 use core::panic;
-use std::collections::HashMap;
 
 use baa::{BitVecOps, BitVecValue};
 use cranelift_entity::{PrimaryMap, entity_impl};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec};
 use wellen::{Hierarchy, Scope, ScopeRef, SignalRef, VarRef};
 
-use crate::control::{AllControl, ControlInfo, PathDescriptorInfo};
-use crate::design::InvokeTarget::{Control, Group};
+use crate::control::{ControlInfo, PathDescriptorInfo};
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct CellId(u32);
@@ -320,7 +318,9 @@ impl Design {
                         );
                         out.append(&mut group_stacks);
                     }
-                    InvokeTarget::Control(_) => {panic!("Group should not invoke a Control node!")}
+                    InvokeTarget::Control(_) => {
+                        panic!("Group should not invoke a Control node!")
+                    }
                 }
             }
         }
@@ -346,6 +346,10 @@ impl Design {
             }
         }
 
+        for (_, control) in self.controls.iter_mut() {
+            control.go_idx = to_index[&control.go];
+        }
+
         for (_, group) in self.groups.iter_mut() {
             group.probe_idx = to_index[&group.probe];
         }
@@ -363,6 +367,10 @@ impl Design {
                 signals.push(main_go_probe);
                 signals.push(main_done_probe);
             }
+        }
+
+        for control in self.controls.values() {
+            signals.push(control.go);
         }
 
         for group in self.groups.values() {
@@ -384,9 +392,10 @@ impl Design {
         &mut self,
         h: &Hierarchy,
         s: ScopeRef,
-        c: ControlInfo,
-        component: String,
+        c: &ControlInfo,
+        component: &String,
     ) -> Result<(FxHashMap<String, Option<ControlId>>, Option<ControlId>)> {
+        println!("component name: {component}");
         // Add Control into the tree, and return a map of groups with their control parent,
         // along with the top-level ControlId if one exists.
         // NOTE: If the component has a single-group control, the second entry will be None.
@@ -396,42 +405,44 @@ impl Design {
         let mut descriptor_to_id: FxHashMap<String, ControlId> =
             FxHashMap::default();
 
-        let descriptors = c.descriptors(&component);
+        let descriptors = c.descriptors(component);
         // let ctrl_map = descriptors.control_pos;
 
         // iterate through control par descriptors and construct Control nodes
         for (d, pos_set) in descriptors.control_pos.iter() {
             let (pretty, pos) = c.get_pretty(&pos_set)?;
-            let tdcc_info_vec = c.get_tdcc(pos)?;
-            assert_eq!(tdcc_info_vec.len(), 1);
-            let name = tdcc_info_vec.iter().next().unwrap().name.clone();
+            // any pos without an entry in tdcc was compiled away; we ignore these.
+            if let Some(tdcc_info_vec) = c.get_tdcc(pos)? {
+                assert_eq!(tdcc_info_vec.len(), 1);
+                let name = tdcc_info_vec.iter().next().unwrap().name.clone();
 
-            let ctrl_scope = get_scope(h, &h[s], &name)?;
-            let go_ref = get_var(h, &h[ctrl_scope], "go")?;
-            let go = h[go_ref].signal_ref();
+                let ctrl_scope = get_scope(h, &h[s], &name)?;
+                let go_ref = get_var(h, &h[ctrl_scope], "go")?;
+                let go = h[go_ref].signal_ref();
 
-            let ctrl = Control {
-                name,
-                go,
-                invokes: smallvec![],
-                go_idx: u32::MAX,
-                pos,
-                pretty,
-            };
-            let ctrl_id = self.controls.push(ctrl);
-            pos_to_id.insert(pos, ctrl_id);
-            descriptor_to_id.insert(d, ctrl_id);
+                let ctrl = Control {
+                    name,
+                    go,
+                    invokes: smallvec![],
+                    go_idx: u32::MAX,
+                    pos,
+                    pretty,
+                };
+                let ctrl_id = self.controls.push(ctrl);
+                pos_to_id.insert(pos, ctrl_id);
+                descriptor_to_id.insert(d.clone(), ctrl_id);
+            }
         }
 
         // compute groups' parent info (reverse sort for easier checking)
         let mut ctrl_desc_rev_sorted =
-            descriptors.control_pos.keys().collect::<Vec<_>>();
+            descriptor_to_id.keys().collect::<Vec<_>>();
         ctrl_desc_rev_sorted.sort();
         ctrl_desc_rev_sorted.reverse();
 
         for (idx, desc) in ctrl_desc_rev_sorted.iter().enumerate() {
             let ctrl_id = descriptor_to_id[*desc];
-            let control = self.controls[ctrl_id];
+            let control = self.controls.get(ctrl_id).unwrap();
             let mut found = false;
             let mut i = idx + 1;
             while i < ctrl_desc_rev_sorted.len() - 1 {
@@ -439,18 +450,20 @@ impl Design {
                 if desc.starts_with(maybe_parent) {
                     // maybe_parent --> desc invoke
                     let invoke = Invoke {
-                        _name: control.name,
+                        _name: control.name.clone(),
                         probe: control.go,
-                        target: Control(ctrl_id),
+                        target: InvokeTarget::Control(ctrl_id),
                         probe_idx: u32::MAX,
                     };
                     let invoke_id = self.invokes.push(invoke);
                     let parent_ctrl_id = descriptor_to_id[maybe_parent];
-                    let parent_ctrl = self.controls[parent_ctrl_id];
+                    let parent_ctrl =
+                        self.controls.get_mut(parent_ctrl_id).unwrap();
                     parent_ctrl.invokes.push(invoke_id);
                     found = true;
                     break;
                 }
+                i += 1;
             }
             if !found {
                 // the only ctrl node without a parent should be the toplevel control node
@@ -460,9 +473,9 @@ impl Design {
         }
 
         let out = Self::groups_to_ctrl_parent(
-            &mut descriptor_to_id,
+            &descriptor_to_id,
             descriptors,
-            &mut ctrl_desc_rev_sorted,
+            &ctrl_desc_rev_sorted,
         );
 
         Ok((out, toplevel_ctrl))
@@ -471,7 +484,7 @@ impl Design {
     fn groups_to_ctrl_parent(
         descriptor_to_id: &FxHashMap<String, ControlId>,
         descriptors: &PathDescriptorInfo,
-        ctrl_desc_sorted: &mut Vec<&String>,
+        ctrl_desc_sorted: &Vec<&String>,
     ) -> FxHashMap<String, Option<ControlId>> {
         let mut out: FxHashMap<String, Option<ControlId>> =
             FxHashMap::default();
@@ -518,7 +531,7 @@ impl Design {
             probe_idxs: None,
         };
         // add control nodes for main
-        self.scan_probes(h, main_scope, &mut main_cell)?;
+        self.scan_probes(h, main_scope, &mut main_cell, &c)?;
         self.main = self.cells.push(main_cell);
         Ok(())
     }
@@ -529,10 +542,10 @@ impl Design {
         h: &Hierarchy,
         cell_scope: ScopeRef,
         cell: &mut Cell,
-        c: ControlInfo,
+        c: &ControlInfo,
     ) -> Result<()> {
         let (group_to_ctrl_parent, top_ctrl_opt) =
-            self.populate_control(h, cell_scope, c, cell.name)?;
+            self.populate_control(h, cell_scope, c, &cell.name)?;
         if let Some(top_ctrl) = top_ctrl_opt {
             cell.control.push(top_ctrl);
         }
@@ -638,7 +651,7 @@ impl Design {
                         if !structurally_invoked_group_names.contains(&name) {
                             // only create a group entry if this group was not structurally enabled.
                             let groupid = self.groups.push(Group {
-                                name,
+                                name: name.clone(),
                                 probe,
                                 invokes,
                                 probe_idx: u32::MAX,
@@ -649,7 +662,7 @@ impl Design {
                                 let invokeid = self.invokes.push(Invoke {
                                     _name: name,
                                     probe,
-                                    target: Group(groupid),
+                                    target: InvokeTarget::Group(groupid),
                                     probe_idx: u32::MAX,
                                 });
                                 self.controls[*ctrl_parent]
@@ -705,7 +718,14 @@ impl Design {
                                 probes: None,
                                 probe_idxs: None,
                             };
-                            self.scan_probes(h, scope, &mut cell_instance)?;
+                            if !is_primitive {
+                                self.scan_probes(
+                                    h,
+                                    scope,
+                                    &mut cell_instance,
+                                    c,
+                                )?;
+                            }
                             let cell_id = self.cells.push(cell_instance);
                             cell.instances.push(cell_id);
                             cell_id

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -1,5 +1,6 @@
 mod control;
 mod design;
+mod shared_cells;
 mod visuals;
 
 use anyhow::{Context, Ok, Result, anyhow};
@@ -9,7 +10,7 @@ use rustc_hash::FxHashMap;
 use wellen::{stream::SignalValues, *};
 
 use crate::design::Design;
-use crate::visuals::{compute_flame, write_flame, FlameCount};
+use crate::visuals::{FlameCount, compute_flame, write_flame};
 
 #[derive(Parser, Debug)]
 #[command(name = "petal")]
@@ -28,7 +29,9 @@ struct Args {
     #[arg(long)]
     scaled_flame_out: Option<String>,
     #[arg(long)]
-    flat_flame_out: Option<String>
+    flat_flame_out: Option<String>,
+    #[arg(value_name = "SHARED_CELLS", index = 5)]
+    shared_cells: String,
 }
 
 /// Reads a boolean value from a signal.
@@ -50,6 +53,9 @@ fn main() -> Result<()> {
         args.control_pos_filename,
     )?;
 
+    let shared_cells =
+        crate::shared_cells::SharedCellsInfo::new(args.shared_cells)?;
+
     let opts = LoadOptions {
         multi_thread: true,
         remove_scopes_with_empty_name: false,
@@ -59,7 +65,7 @@ fn main() -> Result<()> {
         .with_context(|| format!("Failed to load {}", args.filename))?;
 
     // static tree
-    let design = Design::new(wav.hierarchy(), ctrl_info)?;
+    let design = Design::new(wav.hierarchy(), ctrl_info, shared_cells)?;
 
     // all probe signals we would need to track
     let signals = design.get_signals();
@@ -98,22 +104,21 @@ fn main() -> Result<()> {
 
     // Compute the trace (stacks for each active cycle) from probe_values
     let mut cycle_count = -1;
-    let mut flame_info : FxHashMap<String, FlameCount> = FxHashMap::default();
+    let mut flame_info: FxHashMap<String, FlameCount> = FxHashMap::default();
     for value in probe_values.iter() {
         let stacks = design.compute_cycle_trace(value)?;
         if !stacks.is_empty() {
-            cycle_count += 1;
-            println!("{cycle_count}");
-            for stack in stacks.iter() {
-                let stack_str = stack.join(", ");
-                println!("	[{stack_str}]");
-            }
-        compute_flame(stacks, &mut flame_info)?;
+            // cycle_count += 1;
+            // println!("{cycle_count}");
+            // for stack in stacks.iter() {
+            //     let stack_str = stack.join(", ");
+            //     println!("	[{stack_str}]");
+            // }
+            compute_flame(stacks, &mut flame_info)?;
         }
     }
 
     write_flame(flame_info, args.scaled_flame_out, args.flat_flame_out)?;
-
 
     Ok(())
 }

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -1,12 +1,15 @@
 mod control;
 mod design;
+mod visuals;
 
 use anyhow::{Context, Ok, Result, anyhow};
 use baa::{BitVecMutOps, BitVecValue};
 use clap::Parser;
+use rustc_hash::FxHashMap;
 use wellen::{stream::SignalValues, *};
 
 use crate::design::Design;
+use crate::visuals::{compute_flame, write_flame, FlameCount};
 
 #[derive(Parser, Debug)]
 #[command(name = "petal")]
@@ -17,11 +20,15 @@ struct Args {
     #[arg(value_name = "WAV", index = 1)]
     filename: String,
     #[arg(value_name = "TDCC", index = 2)]
-    tdcc_filename: String,
+    tdcc_filename: String, // fsm.json
     #[arg(value_name = "PATH_DESC", index = 3)]
-    path_descriptor_filename: String,
+    path_descriptor_filename: String, // path-descriptor.json
     #[arg(value_name = "CTRL_POS", index = 4)]
-    control_pos_filename: String,
+    control_pos_filename: String, // ctrl-pos.json
+    #[arg(long)]
+    scaled_flame_out: Option<String>,
+    #[arg(long)]
+    flat_flame_out: Option<String>
 }
 
 /// Reads a boolean value from a signal.
@@ -91,18 +98,22 @@ fn main() -> Result<()> {
 
     // Compute the trace (stacks for each active cycle) from probe_values
     let mut cycle_count = -1;
+    let mut flame_info : FxHashMap<String, FlameCount> = FxHashMap::default();
     for value in probe_values.iter() {
-        // .take(15) // for debugging
         let stacks = design.compute_cycle_trace(value)?;
         if !stacks.is_empty() {
             cycle_count += 1;
             println!("{cycle_count}");
-            for stack in stacks {
+            for stack in stacks.iter() {
                 let stack_str = stack.join(", ");
                 println!("	[{stack_str}]");
             }
+        compute_flame(stacks, &mut flame_info)?;
         }
     }
+
+    write_flame(flame_info, args.scaled_flame_out, args.flat_flame_out)?;
+
 
     Ok(())
 }

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
 
     // static tree
     let design = Design::new(wav.hierarchy(), ctrl_info)?;
-    
+
     // all probe signals we would need to track
     let signals = design.get_signals();
 

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -26,12 +26,12 @@ struct Args {
     path_descriptor_filename: String, // path-descriptor.json
     #[arg(value_name = "CTRL_POS", index = 4)]
     control_pos_filename: String, // ctrl-pos.json
+    #[arg(value_name = "SHARED_CELLS", index = 5)]
+    shared_cells: String, // shared-cells.json
     #[arg(long)]
     scaled_flame_out: Option<String>,
     #[arg(long)]
     flat_flame_out: Option<String>,
-    #[arg(value_name = "SHARED_CELLS", index = 5)]
-    shared_cells: String,
     #[arg(long, default_value_t = 100)]
     num_print_cycles: i32,
 }

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -37,7 +37,7 @@ fn read_bool(signal: SignalRef, values: &SignalValues) -> bool {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    crate::control::AllControl::new(
+    let ctrl_info = crate::control::AllControl::new(
         args.tdcc_filename,
         args.path_descriptor_filename,
         args.control_pos_filename,
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
         .with_context(|| format!("Failed to load {}", args.filename))?;
 
     // static tree
-    let design = Design::new(wav.hierarchy())?;
+    let design = Design::new(wav.hierarchy(), ctrl_info)?;
 
     // all probe signals we would need to track
     let signals = design.get_signals();

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -55,7 +55,6 @@ fn main() -> Result<()> {
     let design = Design::new(wav.hierarchy(), ctrl_info)?;
 
     println!("{design:?}");
-    panic!("done for now");
 
     // all probe signals we would need to track
     let signals = design.get_signals();

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -54,6 +54,8 @@ fn main() -> Result<()> {
     // static tree
     let design = Design::new(wav.hierarchy(), ctrl_info)?;
 
+    println!("{design:?}");
+
     // all probe signals we would need to track
     let signals = design.get_signals();
 

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -32,6 +32,8 @@ struct Args {
     flat_flame_out: Option<String>,
     #[arg(value_name = "SHARED_CELLS", index = 5)]
     shared_cells: String,
+    #[arg(long, default_value_t = 100)]
+    num_print_cycles: i32,
 }
 
 /// Reads a boolean value from a signal.
@@ -103,17 +105,19 @@ fn main() -> Result<()> {
     println!("Number of clock ticks: {}", probe_values.len());
 
     // Compute the trace (stacks for each active cycle) from probe_values
-    let mut cycle_count = -1;
+    let mut cycle_count: i32 = -1;
     let mut flame_info: FxHashMap<String, FlameCount> = FxHashMap::default();
     for value in probe_values.iter() {
         let stacks = design.compute_cycle_trace(value)?;
         if !stacks.is_empty() {
-            // cycle_count += 1;
-            // println!("{cycle_count}");
-            // for stack in stacks.iter() {
-            //     let stack_str = stack.join(", ");
-            //     println!("	[{stack_str}]");
-            // }
+            cycle_count += 1;
+            if args.num_print_cycles >= cycle_count {
+                println!("{cycle_count}");
+                for stack in stacks.iter() {
+                    let stack_str = stack.join(", ");
+                    println!("	[{stack_str}]");
+                }
+            }
             compute_flame(stacks, &mut flame_info)?;
         }
     }

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -37,7 +37,7 @@ fn read_bool(signal: SignalRef, values: &SignalValues) -> bool {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    crate::control::parse(
+    crate::control::AllControl::new(
         args.tdcc_filename,
         args.path_descriptor_filename,
         args.control_pos_filename,

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -1,3 +1,4 @@
+mod control;
 mod design;
 
 use anyhow::{Context, Ok, Result, anyhow};
@@ -15,6 +16,12 @@ use crate::design::Design;
 struct Args {
     #[arg(value_name = "WAV", index = 1)]
     filename: String,
+    #[arg(value_name = "TDCC", index = 2)]
+    tdcc_filename: String,
+    #[arg(value_name = "PATH_DESC", index = 3)]
+    path_descriptor_filename: String,
+    #[arg(value_name = "CTRL_POS", index = 4)]
+    control_pos_filename: String,
 }
 
 /// Reads a boolean value from a signal.
@@ -29,6 +36,12 @@ fn read_bool(signal: SignalRef, values: &SignalValues) -> bool {
 
 fn main() -> Result<()> {
     let args = Args::parse();
+
+    crate::control::parse(
+        args.tdcc_filename,
+        args.path_descriptor_filename,
+        args.control_pos_filename,
+    )?;
 
     let opts = LoadOptions {
         multi_thread: true,

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -37,7 +37,7 @@ fn read_bool(signal: SignalRef, values: &SignalValues) -> bool {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let ctrl_info = crate::control::AllControl::new(
+    let ctrl_info = crate::control::ControlInfo::new(
         args.tdcc_filename,
         args.path_descriptor_filename,
         args.control_pos_filename,
@@ -55,6 +55,7 @@ fn main() -> Result<()> {
     let design = Design::new(wav.hierarchy(), ctrl_info)?;
 
     println!("{design:?}");
+    panic!("done for now");
 
     // all probe signals we would need to track
     let signals = design.get_signals();

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -53,9 +53,7 @@ fn main() -> Result<()> {
 
     // static tree
     let design = Design::new(wav.hierarchy(), ctrl_info)?;
-
-    println!("{design:?}");
-
+    
     // all probe signals we would need to track
     let signals = design.get_signals();
 

--- a/tools/petal/src/shared_cells.rs
+++ b/tools/petal/src/shared_cells.rs
@@ -5,15 +5,16 @@ use std::collections::BTreeMap;
 use std::fs::File;
 
 #[derive(PartialEq, Eq, Hash, Clone, Deserialize)]
+/// An instance of a cell being shared; obtained from cell-share compiler pass.
 struct ShareEntry {
     original: String, // cell to be replaced
     new: String,      // replacement cell (shared)
     cell_type: String,
 }
 
-// shared_cells: BTreeMap<String, Vec<ShareEntry>>
-
+/// Maps shared cells in each component.
 pub struct SharedCellsInfo {
+    /// component --> {original cell --> new cell}
     shared_map: FxHashMap<String, FxHashMap<String, String>>,
 }
 
@@ -37,6 +38,7 @@ impl SharedCellsInfo {
         Ok(Self { shared_map })
     }
 
+    /// Returns the replacement (new) cell for a potentially shared cell, if one exists.
     pub fn get_replacement(
         &self,
         component: String,

--- a/tools/petal/src/shared_cells.rs
+++ b/tools/petal/src/shared_cells.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs::File;
+
+#[derive(PartialEq, Eq, Hash, Clone, Deserialize)]
+struct ShareEntry {
+    original: String, // cell to be replaced
+    new: String,      // replacement cell (shared)
+    cell_type: String,
+}
+
+// shared_cells: BTreeMap<String, Vec<ShareEntry>>
+
+pub struct SharedCellsInfo {
+    shared_map: FxHashMap<String, FxHashMap<String, String>>,
+}
+
+impl SharedCellsInfo {
+    pub fn new(fname: String) -> Result<Self> {
+        let mut shared_map: FxHashMap<String, FxHashMap<String, String>> =
+            FxHashMap::default();
+        let f = File::open(fname)?;
+        let shared_cells: BTreeMap<String, Vec<ShareEntry>> =
+            serde_json::from_reader(f).unwrap();
+
+        for (component, shared_vec) in shared_cells {
+            // old -> new
+            let mut internal_map: FxHashMap<String, String> =
+                FxHashMap::default();
+            for shared in shared_vec {
+                internal_map.insert(shared.original, shared.new);
+            }
+            shared_map.insert(component, internal_map);
+        }
+        Ok(Self { shared_map })
+    }
+
+    pub fn get_replacement(
+        &self,
+        component: String,
+        name: String,
+    ) -> Option<String> {
+        self.shared_map.get(&component)?.get(&name).cloned()
+    }
+}

--- a/tools/petal/src/shared_cells.rs
+++ b/tools/petal/src/shared_cells.rs
@@ -3,6 +3,7 @@ use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs::File;
+use std::path::Path;
 
 #[derive(PartialEq, Eq, Hash, Clone, Deserialize)]
 /// An instance of a cell being shared; obtained from cell-share compiler pass.
@@ -22,18 +23,21 @@ impl SharedCellsInfo {
     pub fn new(fname: String) -> Result<Self> {
         let mut shared_map: FxHashMap<String, FxHashMap<String, String>> =
             FxHashMap::default();
-        let f = File::open(fname)?;
-        let shared_cells: BTreeMap<String, Vec<ShareEntry>> =
-            serde_json::from_reader(f).unwrap();
+        let p = Path::new(&fname);
+        if p.exists() {
+            let f = File::open(fname)?;
+            let shared_cells: BTreeMap<String, Vec<ShareEntry>> =
+                serde_json::from_reader(f).unwrap();
 
-        for (component, shared_vec) in shared_cells {
-            // old -> new
-            let mut internal_map: FxHashMap<String, String> =
-                FxHashMap::default();
-            for shared in shared_vec {
-                internal_map.insert(shared.original, shared.new);
+            for (component, shared_vec) in shared_cells {
+                // old -> new
+                let mut internal_map: FxHashMap<String, String> =
+                    FxHashMap::default();
+                for shared in shared_vec {
+                    internal_map.insert(shared.original, shared.new);
+                }
+                shared_map.insert(component, internal_map);
             }
-            shared_map.insert(component, internal_map);
         }
         Ok(Self { shared_map })
     }

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -19,26 +19,24 @@ pub fn compute_flame(
     let mut stack_strings: Vec<String> =
         cycle_trace.iter().map(|stack| stack.join(";")).collect();
     stack_strings.sort();
-    let mut acc = 0;
-    for stack_string in stack_strings {
+    for (acc, stack_string) in stack_strings.iter().enumerate() {
         let scaled = if acc == cycle_trace.len() - 1 {
             (1.0f64) - (normalizer * ((cycle_trace.iter().len() - 1) as f64))
         } else {
             normalizer
         };
-        if let Some(curr) = out.get_mut(&stack_string) {
+        if let Some(curr) = out.get_mut(stack_string) {
             curr.scaled += scaled;
             curr.flat += 1.0;
         } else {
             out.insert(
-                stack_string,
+                stack_string.to_string(),
                 FlameCount {
                     scaled,
                     flat: 1.0,
                 },
             );
         }
-        acc += 1;
     }
     Ok(())
 }

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -1,0 +1,75 @@
+use crate::design::Stack;
+use anyhow::{Ok, Result};
+use rustc_hash::FxHashMap;
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Write};
+
+pub struct FlameCount {
+    scaled: f64,
+    flat: f64,
+}
+
+pub fn compute_flame(
+    cycle_trace: Vec<Stack>,
+    out: &mut FxHashMap<String, FlameCount>,
+) -> Result<()> {
+    let mut normalizer = (1.0f64) / (cycle_trace.len() as f64);
+    // attempt to mirror Python Petal's rounding to three decimal places.
+    normalizer = (normalizer * 1000.0).round() / 1000.0;
+    let mut stack_strings: Vec<String> =
+        cycle_trace.iter().map(|stack| stack.join(";")).collect();
+    stack_strings.sort();
+    let mut acc = 0;
+    for stack_string in stack_strings {
+        let scaled = if (acc == cycle_trace.len() - 1) {
+            (1.0f64) - (normalizer * ((cycle_trace.iter().len() - 1) as f64))
+        } else {
+            normalizer
+        };
+        if let Some(curr) = out.get_mut(&stack_string) {
+            curr.scaled += scaled;
+            curr.flat += 1.0;
+        } else {
+            out.insert(
+                stack_string,
+                FlameCount {
+                    scaled,
+                    flat: 1.0,
+                },
+            );
+        }
+        acc += 1;
+    }
+    Ok(())
+}
+
+fn get_buffer(path_opt: Option<String>) -> Result<Option<BufWriter<File>>> {
+    if let Some(path) = path_opt {
+        let sf = File::create_new(path)?;
+        Ok(Some(BufWriter::new(sf)))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn write_flame(
+    flame_info: FxHashMap<String, FlameCount>,
+    scaled_flame_opt: Option<String>,
+    folded_flame_opt: Option<String>,
+) -> Result<()> {
+    let mut scaled_buffer = get_buffer(scaled_flame_opt)?;
+    if let Some(mut buffer) = scaled_buffer {
+        for (s, f) in flame_info.iter() {
+            // scaled flame graphs should be multiplied by 1000 to prevent the flame graph script
+            // erroring out.
+            writeln!(buffer, "{s} {:.1}", (f.scaled * 1000.0))?;
+        }
+    }
+    let folded_buffer = get_buffer(folded_flame_opt)?;
+    if let Some(mut buffer) = folded_buffer {
+        for (s, f) in flame_info.iter() {
+            writeln!(buffer, "{s} {}", f.flat)?;
+        }
+    }
+    Ok(())
+}

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -1,7 +1,7 @@
 use crate::design::Stack;
 use anyhow::{Ok, Result};
 use rustc_hash::FxHashMap;
-use std::fs::{File};
+use std::fs::File;
 use std::io::{BufWriter, Write};
 
 /// Represents the flame graph values (how much for a single stack.
@@ -35,8 +35,7 @@ pub fn compute_flame(
                 stack_string.to_string(),
                 FlameCount {
                     scaled,
-                    flat: 1.0,
-                },
+                    flat: 1.0 },
             );
         }
     }

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -1,12 +1,12 @@
-use std::fs;
 use crate::design::Stack;
 use anyhow::{Ok, Result};
 use rustc_hash::FxHashMap;
+use std::fs;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-/// Represents the flame graph values (how much for a single stack.
+/// Represents the flame graph values (how much for a single stack).
 pub struct FlameCount {
     scaled: f64,
     flat: f64,

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -33,9 +33,7 @@ pub fn compute_flame(
         } else {
             out.insert(
                 stack_string.to_string(),
-                FlameCount {
-                    scaled,
-                    flat: 1.0 },
+                FlameCount { scaled, flat: 1.0 },
             );
         }
     }

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -1,8 +1,8 @@
 use crate::design::Stack;
 use anyhow::{Ok, Result};
 use rustc_hash::FxHashMap;
-use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Write};
+use std::fs::{File};
+use std::io::{BufWriter, Write};
 
 pub struct FlameCount {
     scaled: f64,
@@ -21,7 +21,7 @@ pub fn compute_flame(
     stack_strings.sort();
     let mut acc = 0;
     for stack_string in stack_strings {
-        let scaled = if (acc == cycle_trace.len() - 1) {
+        let scaled = if acc == cycle_trace.len() - 1 {
             (1.0f64) - (normalizer * ((cycle_trace.iter().len() - 1) as f64))
         } else {
             normalizer
@@ -57,7 +57,7 @@ pub fn write_flame(
     scaled_flame_opt: Option<String>,
     folded_flame_opt: Option<String>,
 ) -> Result<()> {
-    let mut scaled_buffer = get_buffer(scaled_flame_opt)?;
+    let scaled_buffer = get_buffer(scaled_flame_opt)?;
     if let Some(mut buffer) = scaled_buffer {
         for (s, f) in flame_info.iter() {
             // scaled flame graphs should be multiplied by 1000 to prevent the flame graph script

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -4,11 +4,13 @@ use rustc_hash::FxHashMap;
 use std::fs::{File};
 use std::io::{BufWriter, Write};
 
+/// Represents the flame graph values (how much for a single stack.
 pub struct FlameCount {
     scaled: f64,
     flat: f64,
 }
 
+/// Update the flame graph count given the trace for a single cycle.
 pub fn compute_flame(
     cycle_trace: Vec<Stack>,
     out: &mut FxHashMap<String, FlameCount>,
@@ -41,6 +43,7 @@ pub fn compute_flame(
     Ok(())
 }
 
+/// Helper function to write_flame() that returns a BufWriter for a flame graph if requested.
 fn get_buffer(path_opt: Option<String>) -> Result<Option<BufWriter<File>>> {
     if let Some(path) = path_opt {
         let sf = File::create_new(path)?;
@@ -50,6 +53,7 @@ fn get_buffer(path_opt: Option<String>) -> Result<Option<BufWriter<File>>> {
     }
 }
 
+/// Writes a scaled/flattened flame graph to scaled_flame_opt/folded_flame_opt if requested.
 pub fn write_flame(
     flame_info: FxHashMap<String, FlameCount>,
     scaled_flame_opt: Option<String>,
@@ -59,7 +63,7 @@ pub fn write_flame(
     if let Some(mut buffer) = scaled_buffer {
         for (s, f) in flame_info.iter() {
             // scaled flame graphs should be multiplied by 1000 to prevent the flame graph script
-            // erroring out.
+            // erroring out. (A script later divides by 1000)
             writeln!(buffer, "{s} {:.1}", (f.scaled * 1000.0))?;
         }
     }

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -1,8 +1,10 @@
+use std::fs;
 use crate::design::Stack;
 use anyhow::{Ok, Result};
 use rustc_hash::FxHashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
+use std::path::Path;
 
 /// Represents the flame graph values (how much for a single stack.
 pub struct FlameCount {
@@ -42,8 +44,12 @@ pub fn compute_flame(
 
 /// Helper function to write_flame() that returns a BufWriter for a flame graph if requested.
 fn get_buffer(path_opt: Option<String>) -> Result<Option<BufWriter<File>>> {
-    if let Some(path) = path_opt {
-        let sf = File::create_new(path)?;
+    if let Some(path_str) = path_opt {
+        let path = Path::new(&path_str);
+        if let Some(d) = path.parent() {
+            fs::create_dir_all(d)?;
+        }
+        let sf = File::create(path)?;
         Ok(Some(BufWriter::new(sf)))
     } else {
         Ok(None)

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -60,16 +60,19 @@ pub fn write_flame(
     folded_flame_opt: Option<String>,
 ) -> Result<()> {
     let scaled_buffer = get_buffer(scaled_flame_opt)?;
+    // sort keys to get deterministic output.
+    let mut sorted_keys = flame_info.keys().collect::<Vec<_>>();
+    sorted_keys.sort();
     if let Some(mut buffer) = scaled_buffer {
-        for (s, f) in flame_info.iter() {
-            // scaled flame graphs should be multiplied by 1000 to prevent the flame graph script
-            // erroring out. (A script later divides by 1000)
+        for &s in sorted_keys.iter() {
+            let f = flame_info.get(s).unwrap();
             writeln!(buffer, "{s} {:.1}", (f.scaled * 1000.0))?;
         }
     }
     let folded_buffer = get_buffer(folded_flame_opt)?;
     if let Some(mut buffer) = folded_buffer {
-        for (s, f) in flame_info.iter() {
+        for &s in sorted_keys.iter() {
+            let f = flame_info.get(s).unwrap();
             writeln!(buffer, "{s} {}", f.flat)?;
         }
     }

--- a/tools/petal/test/language-tutorial-iterate.expect
+++ b/tools/petal/test/language-tutorial-iterate.expect
@@ -1,99 +1,99 @@
 Number of clock ticks: 41
 0
-	[main, init, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), init, counter (primitive)]
 1
-	[main]
+	[main, tdcc ~ L68:seq (ctrl)]
 2
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 3
-	[main]
+	[main, tdcc ~ L68:seq (ctrl)]
 4
-	[main, incr, add2 (primitive)]
-	[main, incr, counter (primitive)]
-	[main, read, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, add2 (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), read, val (primitive)]
 5
-	[main, upd, add (primitive)]
-	[main, upd, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, add (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, val (primitive)]
 6
-	[main, write, mem (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), write, mem (primitive)]
 7
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 8
-	[main, incr, add2 (primitive)]
-	[main, incr, counter (primitive)]
-	[main, read, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, add2 (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), read, val (primitive)]
 9
-	[main, upd, add (primitive)]
-	[main, upd, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, add (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, val (primitive)]
 10
-	[main, write, mem (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), write, mem (primitive)]
 11
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 12
-	[main, incr, add2 (primitive)]
-	[main, incr, counter (primitive)]
-	[main, read, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, add2 (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), read, val (primitive)]
 13
-	[main, upd, add (primitive)]
-	[main, upd, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, add (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, val (primitive)]
 14
-	[main, write, mem (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), write, mem (primitive)]
 15
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 16
-	[main, incr, add2 (primitive)]
-	[main, incr, counter (primitive)]
-	[main, read, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, add2 (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), read, val (primitive)]
 17
-	[main, upd, add (primitive)]
-	[main, upd, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, add (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, val (primitive)]
 18
-	[main, write, mem (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), write, mem (primitive)]
 19
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 20
-	[main, incr, add2 (primitive)]
-	[main, incr, counter (primitive)]
-	[main, read, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, add2 (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), read, val (primitive)]
 21
-	[main, upd, add (primitive)]
-	[main, upd, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, add (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, val (primitive)]
 22
-	[main, write, mem (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), write, mem (primitive)]
 23
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 24
-	[main, incr, add2 (primitive)]
-	[main, incr, counter (primitive)]
-	[main, read, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, add2 (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), read, val (primitive)]
 25
-	[main, upd, add (primitive)]
-	[main, upd, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, add (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, val (primitive)]
 26
-	[main, write, mem (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), write, mem (primitive)]
 27
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 28
-	[main, incr, add2 (primitive)]
-	[main, incr, counter (primitive)]
-	[main, read, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, add2 (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), read, val (primitive)]
 29
-	[main, upd, add (primitive)]
-	[main, upd, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, add (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, val (primitive)]
 30
-	[main, write, mem (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), write, mem (primitive)]
 31
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 32
-	[main, incr, add2 (primitive)]
-	[main, incr, counter (primitive)]
-	[main, read, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, add2 (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), incr, counter (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), read, val (primitive)]
 33
-	[main, upd, add (primitive)]
-	[main, upd, val (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, add (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), upd, val (primitive)]
 34
-	[main, write, mem (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), write, mem (primitive)]
 35
-	[main, cond, lt (primitive)]
+	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 36
-	[main]
+	[main, tdcc ~ L68:seq (ctrl)]

--- a/tools/petal/test/language-tutorial-iterate.expect
+++ b/tools/petal/test/language-tutorial-iterate.expect
@@ -97,3 +97,13 @@ Number of clock ticks: 41
 	[main, tdcc ~ L68:seq (ctrl), cond, lt (primitive)]
 36
 	[main, tdcc ~ L68:seq (ctrl)]
+====FLAT FLAME OUTPUT====
+main;tdcc ~ L68:seq (ctrl) 3
+main;tdcc ~ L68:seq (ctrl);cond;lt (primitive) 9
+main;tdcc ~ L68:seq (ctrl);incr;add2 (primitive) 8
+main;tdcc ~ L68:seq (ctrl);incr;counter (primitive) 8
+main;tdcc ~ L68:seq (ctrl);init;counter (primitive) 1
+main;tdcc ~ L68:seq (ctrl);read;val (primitive) 8
+main;tdcc ~ L68:seq (ctrl);upd;add (primitive) 8
+main;tdcc ~ L68:seq (ctrl);upd;val (primitive) 8
+main;tdcc ~ L68:seq (ctrl);write;mem (primitive) 8

--- a/tools/petal/test/pipelined-mac.expect
+++ b/tools/petal/test/pipelined-mac.expect
@@ -1,245 +1,245 @@
 Number of clock ticks: 96
 0
-	[main, init_all, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), init_all, idx0 (primitive)]
 1
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 2
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac0, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac0, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 3
-	[main, invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 4
-	[main, invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 5
-	[main, invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac0, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 6
-	[main, invoke_mac0, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac0, mac [pipelined_mac], stage1, pipe1 (primitive)]
 7
-	[main, invoke_mac0, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
-	[main, invoke_mac0, mac [pipelined_mac], unset_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac0, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac0, mac [pipelined_mac], unset_out_valid, out_valid (primitive)]
 8
-	[main]
+	[main, tdcc ~ L156:seq (ctrl)]
 9
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 10
-	[main]
+	[main, tdcc ~ L156:seq (ctrl)]
 11
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 12
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 13
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 14
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 15
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 16
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 17
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 18
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 19
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 20
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 21
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 22
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 23
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 24
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 25
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 26
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 27
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 28
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 29
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 30
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 31
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 32
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 33
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 34
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 35
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 36
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 37
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 38
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 39
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 40
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 41
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 42
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 43
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 44
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 45
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 46
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 47
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 48
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 49
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 50
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 51
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 52
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 53
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 54
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 55
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 56
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 57
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 58
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 59
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 60
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 61
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 62
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 63
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 64
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 65
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 66
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 67
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 68
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 69
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 70
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 71
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 72
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 73
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 74
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 75
-	[main, store_a, read_a (primitive)]
-	[main, store_b, read_b (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_a, read_a (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), store_b, read_b (primitive)]
 76
-	[main, incr_idx, add0 (primitive)]
-	[main, incr_idx, idx0 (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, add0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), incr_idx, idx0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 77
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage2, pipe2 (primitive)]
 78
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 79
-	[main, invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, mult_pipe (primitive)]
 80
-	[main, invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], stage1, pipe1 (primitive)]
 81
-	[main, invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac1, mac [pipelined_mac], set_stage2_valid, stage2_valid (primitive)]
 82
-	[main, in_range, lt0 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), in_range, lt0 (primitive)]
 83
-	[main]
+	[main, tdcc ~ L156:seq (ctrl)]
 84
-	[main, invoke_mac2, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac2, mac [pipelined_mac], write_data_valid, data_valid_reg (primitive)]
 85
-	[main, invoke_mac2, mac [pipelined_mac], stage2, add (primitive)]
-	[main, invoke_mac2, mac [pipelined_mac], stage2, pipe2 (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac2, mac [pipelined_mac], stage2, add (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac2, mac [pipelined_mac], stage2, pipe2 (primitive)]
 86
-	[main, invoke_mac2, mac [pipelined_mac]]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac2, mac [pipelined_mac]]
 87
-	[main, invoke_mac2, mac [pipelined_mac]]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac2, mac [pipelined_mac]]
 88
-	[main, invoke_mac2, mac [pipelined_mac]]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac2, mac [pipelined_mac]]
 89
-	[main, invoke_mac2, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
-	[main, invoke_mac2, mac [pipelined_mac], unset_stage2_valid, stage2_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac2, mac [pipelined_mac], set_out_valid, out_valid (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), invoke_mac2, mac [pipelined_mac], unset_stage2_valid, stage2_valid (primitive)]
 90
-	[main, save_out, out (primitive)]
+	[main, tdcc ~ L156:seq (ctrl), save_out, out (primitive)]
 91
-	[main]
+	[main, tdcc ~ L156:seq (ctrl)]

--- a/tools/petal/test/pipelined-mac.expect
+++ b/tools/petal/test/pipelined-mac.expect
@@ -243,3 +243,30 @@ Number of clock ticks: 96
 	[main, tdcc ~ L156:seq (ctrl), save_out, out (primitive)]
 91
 	[main, tdcc ~ L156:seq (ctrl)]
+====FLAT FLAME OUTPUT====
+main;tdcc ~ L156:seq (ctrl) 4
+main;tdcc ~ L156:seq (ctrl);in_range;lt0 (primitive) 10
+main;tdcc ~ L156:seq (ctrl);incr_idx;add0 (primitive) 10
+main;tdcc ~ L156:seq (ctrl);incr_idx;idx0 (primitive) 10
+main;tdcc ~ L156:seq (ctrl);init_all;idx0 (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];set_stage2_valid;stage2_valid (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];stage1;mult_pipe (primitive) 3
+main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];stage1;pipe1 (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];unset_out_valid;out_valid (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];write_data_valid;data_valid_reg (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];set_out_valid;out_valid (primitive) 9
+main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];set_stage2_valid;stage2_valid (primitive) 9
+main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];stage1;mult_pipe (primitive) 27
+main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];stage1;pipe1 (primitive) 9
+main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];stage2;add (primitive) 9
+main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];stage2;pipe2 (primitive) 9
+main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];write_data_valid;data_valid_reg (primitive) 9
+main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac] 3
+main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];set_out_valid;out_valid (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];stage2;add (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];stage2;pipe2 (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];unset_stage2_valid;stage2_valid (primitive) 1
+main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];write_data_valid;data_valid_reg (primitive) 1
+main;tdcc ~ L156:seq (ctrl);save_out;out (primitive) 1
+main;tdcc ~ L156:seq (ctrl);store_a;read_a (primitive) 10
+main;tdcc ~ L156:seq (ctrl);store_b;read_b (primitive) 10

--- a/tools/petal/test/structural-enable-cond.expect
+++ b/tools/petal/test/structural-enable-cond.expect
@@ -1,3 +1,5 @@
 Number of clock ticks: 5
 0
 	[main, wr_b, wr_a, a (primitive)]
+====FLAT FLAME OUTPUT====
+main;wr_b;wr_a;a (primitive) 1

--- a/tools/profiler/profiler/visuals/flame.py
+++ b/tools/profiler/profiler/visuals/flame.py
@@ -71,7 +71,7 @@ class FlameTrace:
         Utility function for outputting a flame graph to file.
         """
         with open(flame_out_file, "w") as flame_out:
-            for stack in flame_map:
+            for stack in sorted(flame_map):
                 flame_out.write(f"{stack} {flame_map[stack]}\n")
 
 


### PR DESCRIPTION
This PR brings the Rusted Petal implementation to a real MVP (minimal viable product) - Rusted Petal now outputs flame graphs that should be equivalent to those emitted by Python Petal. This involved adding control nodes into call trees, tracking shared cells, and accumulating stack counts to emit for flame graphs.

This PR also makes Python Petal's flame graph output deterministic via sorting on stack strings to ease differential testing.

## Usage
```
petal [OPTIONS] <WAV> <TDCC> <PATH_DESC> <CTRL_POS> <SHARED_CELLS>
```
where paths for flame graphs (`.folded` files, which are inputs to the flame graph script) can be given conditionally via `--scaled-flame-out` and `--flat-flame-out`.

ex) 
```
cd <CALYX_DIR>/tools/petal
fud2 ../../tests/correctness/pipelined-mac.futil -o svgs/pipelined-mac.svg -s sim.data=../../tests/correctness/pipelined-mac.futil.data  --through profiler --dir fud2-pipelined-mac
cargo run -- fud2-pipelined-mac/instrumented.vcd fud2-pipelined-mac/fsm.json fud2-pipelined-mac/path-descriptors.json fud2-pipelined-mac/ctrl-pos.json fud2-pipelined-mac/shared-cells.json --scaled-flame-out rp-scaled.folded --flat-flame-out rp-flat.folded
```
Will produce scaled/flat flame graphs to `rp-scaled.folded`/`rp-flat.folded`.

NOTE: Scaled flame graph files may be slightly different from Python Petal, most likely because of differences in how floating points are handled in Rust vs Petal. Flat flame graph files should be identical to sorted Python petal flat flame graphs.

## Next Steps

- A fud2 command to run Rusted Petal
- Performance comparisons between Python Petal and Rusted Petal
- Timeline view support
- ADL support