### PR TITLE
[Profiler] fud2 op for running Rusted Petal

### DIFF
--- a/fud2/scripts/profiler.rhai
+++ b/fud2/scripts/profiler.rhai
@@ -53,6 +53,10 @@ fn profiler_non_synth_setup(e) {
     e.rule("parse-vcd", "profiler $in $cell-json $fsm-json $cell-share-json $enable-par-track-json $path-descriptors-json profiler-out $out --print-trace-threshold 100 --ctrl-pos-file $ctrl-pos-json");
     e.rule("parse-vcd-from-adl", "profiler $in $cell-json $fsm-json $cell-share-json $enable-par-track-json $path-descriptors-json profiler-out $out --ctrl-pos-file $ctrl-pos-json --adl-mapping-file $adl-metadata-json --print-trace-threshold 100");
     e.rule("parse-vcd-from-dahlia", "profiler $in $cell-json $fsm-json $cell-share-json $enable-par-track-json $path-descriptors-json profiler-out $out --ctrl-pos-file $ctrl-pos-json --dahlia-parent-map $parent-map --adl-mapping-file $adl-metadata-json --print-trace-threshold 100");
+
+    // rust re-implementation
+    e.config_var_or("rusted_petal", "rusted_petal", "$calyx-base/target/debug/petal");
+    e.rule("rusted-petal-parse-vcd", "$rusted_petal $in $fsm-json $path-descriptors-json $ctrl-pos-json $cell-share-json --scaled-flame-out profiler-out/scaled-flame.folded --flat-flame-out $out");
 }
 
 fn profiler_synth_setup(e) {
@@ -115,7 +119,7 @@ fn py_to_profiled(e, input, output) {
     e.build_cmd([output], "create-visuals", [flamegraph_folded], []);
 }
 
-fn dahlia_to_profiled(e, input, output) {
+fn dahlia_to_profiled(e, input, output) { 
     // compile Dahlia with extra args to give us the hierarchy
     let calyx = "calyx.futil";
     e.build_cmd([calyx], "dahlia-to-calyx", [input], []);
@@ -162,11 +166,11 @@ fn dahlia_to_profiled(e, input, output) {
     // vcd --> flamegraph
     let elems_profiled_json = "elems-profiled.json";
     let flamegraph_folded = "flamegraph.folded";
-    e.build_cmd([flamegraph_folded], "parse-vcd-from-dahlia", [instrumented_vcd], ["$cell-json", "$adl-metadata-json"]);
+        e.build_cmd([flamegraph_folded], "parse-vcd-from-dahlia", [instrumented_vcd], ["$cell-json", "$adl-metadata-json"]);
     e.build_cmd([output], "create-visuals", [flamegraph_folded], []);
 }
 
-fn calyx_to_flamegraph(e, input, output) {
+fn calyx_to_flamegraph(e, input, output, python_impl) {
     // First pass: obtain control metadata information by running metadata-table-generation
     // on the original program and then running the metadata tool on it.
     let metadata_calyx = "metadata-calyx.futil";
@@ -210,16 +214,28 @@ fn calyx_to_flamegraph(e, input, output) {
     // vcd --> flamegraph
     let elems_profiled_json = "elems-profiled.json";
     let flamegraph_folded = "flamegraph.folded";
-    e.build_cmd([flamegraph_folded], "parse-vcd", [instrumented_vcd], ["$cell-json", "$ctrl-pos-json"]);
+    if python_impl {
+        e.build_cmd([flamegraph_folded], "parse-vcd", [instrumented_vcd], ["$cell-json", "$ctrl-pos-json"]);
+    } else {
+        e.build_cmd([flamegraph_folded], "rusted-petal-parse-vcd", [instrumented_vcd], ["$cell-json", "$ctrl-pos-json"]);
+    }
     e.build_cmd([output], "create-visuals", [flamegraph_folded], []);
 }
+
+op(
+    "rusted-petal",
+    [c::calyx_setup, profiling_setup, profiler_non_synth_setup, v::verilator_setup, sim::sim_setup],
+    c::calyx_state,
+    flamegraph,
+    |e, input, output| calyx_to_flamegraph(e, input, output, false)
+);
 
 op(
     "profiler",
     [c::calyx_setup, profiling_setup, profiler_non_synth_setup, v::verilator_setup, sim::sim_setup],
     c::calyx_state,
     flamegraph,
-    |e, input, output| calyx_to_flamegraph(e, input, output)
+    |e, input, output| calyx_to_flamegraph(e, input, output, true)
 );
 
 op(
@@ -227,7 +243,7 @@ op(
     [c::calyx_setup, profiling_setup, profiler_synth_setup, v::verilator_setup, sim::sim_setup],
     c::calyx_state,
     flamegraph,
-    |e, input, output| calyx_to_flamegraph(e, input, output)
+    |e, input, output| calyx_to_flamegraph(e, input, output, true)
 );
 
 op("calyx-py-profiler",

--- a/fud2/tests/snapshots/tests__list_ops.snap
+++ b/fud2/tests/snapshots/tests__list_ops.snap
@@ -1,6 +1,5 @@
 ---
 source: fud2/tests/tests.rs
-snapshot_kind: text
 ---
 [
     (
@@ -152,6 +151,11 @@ snapshot_kind: text
         "relay",
         "relay",
         "calyx",
+    ),
+    (
+        "rusted-petal",
+        "calyx",
+        "flamegraph",
     ),
     (
         "simulate",

--- a/fud2/tests/snapshots/tests__test@plan_calyx-py-profiler.snap
+++ b/fud2/tests/snapshots/tests__test@plan_calyx-py-profiler.snap
@@ -50,6 +50,9 @@ rule parse-vcd-from-adl
   command = profiler $in $cell-json $fsm-json $cell-share-json $enable-par-track-json $path-descriptors-json profiler-out $out --ctrl-pos-file $ctrl-pos-json --adl-mapping-file $adl-metadata-json --print-trace-threshold 100
 rule parse-vcd-from-dahlia
   command = profiler $in $cell-json $fsm-json $cell-share-json $enable-par-track-json $path-descriptors-json profiler-out $out --ctrl-pos-file $ctrl-pos-json --dahlia-parent-map $parent-map --adl-mapping-file $adl-metadata-json --print-trace-threshold 100
+rusted_petal = $calyx-base/target/debug/petal
+rule rusted-petal-parse-vcd
+  command = $rusted_petal $in $fsm-json $path-descriptors-json $ctrl-pos-json $cell-share-json --scaled-flame-out profiler-out/scaled-flame.folded --flat-flame-out $out
 
 verilator = verilator
 cycle-limit = 500000000

--- a/fud2/tests/snapshots/tests__test@plan_profiler.snap
+++ b/fud2/tests/snapshots/tests__test@plan_profiler.snap
@@ -50,6 +50,9 @@ rule parse-vcd-from-adl
   command = profiler $in $cell-json $fsm-json $cell-share-json $enable-par-track-json $path-descriptors-json profiler-out $out --ctrl-pos-file $ctrl-pos-json --adl-mapping-file $adl-metadata-json --print-trace-threshold 100
 rule parse-vcd-from-dahlia
   command = profiler $in $cell-json $fsm-json $cell-share-json $enable-par-track-json $path-descriptors-json profiler-out $out --ctrl-pos-file $ctrl-pos-json --dahlia-parent-map $parent-map --adl-mapping-file $adl-metadata-json --print-trace-threshold 100
+rusted_petal = $calyx-base/target/debug/petal
+rule rusted-petal-parse-vcd
+  command = $rusted_petal $in $fsm-json $path-descriptors-json $ctrl-pos-json $cell-share-json --scaled-flame-out profiler-out/scaled-flame.folded --flat-flame-out $out
 
 verilator = verilator
 cycle-limit = 500000000

--- a/fud2/tests/snapshots/tests__test@plan_rusted-petal.snap
+++ b/fud2/tests/snapshots/tests__test@plan_rusted-petal.snap
@@ -1,16 +1,10 @@
 ---
 source: fud2/tests/tests.rs
-description: "emit plan: dahlia-profiler"
+description: "emit plan: rusted-petal"
 ---
 build-tool = fud2
 rule get-rsrc
   command = $build-tool get-rsrc $out
-
-parent-map = parent-map.json
-dahlia-exe = /test/bin/dahlia
-dahlia-args = 
-rule dahlia-to-calyx
-  command = $dahlia-exe -b calyx --lower -l error $dahlia-args $in > $out
 
 calyx-base = /test/calyx
 calyx-exe = $calyx-base/target/debug/calyx
@@ -82,13 +76,11 @@ rule sim-run
   command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out || (cat $out >&2 && false)
 cycle-limit = 500000000
 
-build calyx.futil: dahlia-to-calyx /input.ext
-  dahlia-args = --parent-map $parent-map
-build metadata-calyx.futil: calyx-pass calyx.futil
+build metadata-calyx.futil: calyx-pass /input.ext
   pass = metadata-table-generation
-build $ctrl-pos-json $adl-metadata-json: parse-metadata-with-adl metadata-calyx.futil
-build $cell-json: component-cells calyx.futil
-build instrumented.sv: calyx calyx.futil
+build $ctrl-pos-json: parse-metadata metadata-calyx.futil
+build $cell-json: component-cells /input.ext
+build instrumented.sv: calyx /input.ext
   backend = verilog
   args = -p metadata-table-generation -p validate -p uniquefy-enables -p dead-group-removal -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json -x uniquefy-enables:par-thread-json=enable-par-track.json -x uniquefy-enables:path-descriptor-json=path-descriptors.json
 build verilator-out/Vtoplevel: verilator-compile-standalone-tb instrumented.sv | tb.sv
@@ -97,7 +89,7 @@ build instrumented.exe: cp verilator-out/Vtoplevel
 build sim.log instrumented.vcd: sim-run instrumented.exe $datadir
   bin = instrumented.exe
   args = +NOTRACE=0 +OUT=instrumented.vcd
-build flamegraph.folded: parse-vcd-from-dahlia instrumented.vcd | $cell-json $adl-metadata-json
+build flamegraph.folded: rusted-petal-parse-vcd instrumented.vcd | $cell-json $ctrl-pos-json
 build /output.ext: create-visuals flamegraph.folded
 
 default /output.ext


### PR DESCRIPTION
This PR adds a fud2 op `rusted-petal` for running Rusted Petal! 

ex) From the Calyx directory:
```
fud2 examples/tutorial/language-tutorial-iterate.futil -o iterate.svg --through rusted-petal -s sim.data=examples/tutorial/data.json --dir fud2-iterate-dir
```
will produce a flat flame graph svg and additional profiler output in `fud2-iterate-dir/profiler-out`.
NOTE: Rusted Petal is still in development and currently only produces flame graphs (no timeline views yet).