### PR TITLE
petal: cache stacks

### DIFF
--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -112,8 +112,16 @@ fn main() -> Result<()> {
     // Compute the trace (stacks for each active cycle) from probe_values
     let mut cycle_count: i32 = -1;
     let mut flame_info: FxHashMap<String, FlameCount> = FxHashMap::default();
+    let mut cache = FxHashMap::default();
     for value in probe_values.iter() {
-        let stacks = design.compute_cycle_trace(value)?;
+        let stacks = match cache.get(value) {
+            Some(stacks) => stacks,
+            None => {
+                let stacks = design.compute_cycle_trace(value)?;
+                cache.insert(value.clone(), stacks);
+                &cache[value]
+            }
+        };
         if !stacks.is_empty() {
             cycle_count += 1;
             if args.num_print_cycles >= cycle_count {

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -14,7 +14,7 @@ pub struct FlameCount {
 
 /// Update the flame graph count given the trace for a single cycle.
 pub fn compute_flame(
-    cycle_trace: Vec<Stack>,
+    cycle_trace: &[Stack],
     out: &mut FxHashMap<String, FlameCount>,
 ) -> Result<()> {
     let mut normalizer = (1.0f64) / (cycle_trace.len() as f64);


### PR DESCRIPTION
Since the stacks are directly derived from the `value` that we observe in the particular cycle, we only need to compute the stacks once for each value that we observe. This cuts down the time it takes to compute the stacks dramatically.