### PR TITLE
[fud2] Fix Vivado errors

### DIFF
--- a/fud2/scripts/synth-verilog-to-report.rhai
+++ b/fud2/scripts/synth-verilog-to-report.rhai
@@ -24,7 +24,8 @@ fn synth_setup(e) {
     e.rule("copy-area", "cp out/hierarchical_utilization_placed.rpt $out");
 
     // Rule for Vivado run, we suppress output since it gets written to a log file anyway
-    e.rule("vivado", "vivado -mode batch -source synth.tcl > /dev/null");
+    // Set XILINX_LOCAL_USER_DATA to fix this issue: https://adaptivesupport.amd.com/s/article/63253
+    e.rule("vivado", "XILINX_LOCAL_USER_DATA=no vivado -mode batch -source synth.tcl > /dev/null");
 
     // Read config variable for the device.xdc file, use default one otherwise
     e.config_var_or("device_xdc", "synth-verilog.constraints", "default.xdc");

--- a/fud2/tests/snapshots/tests__test@plan_area-report-to-flamegraph.snap
+++ b/fud2/tests/snapshots/tests__test@plan_area-report-to-flamegraph.snap
@@ -20,7 +20,7 @@ rule copy-timing
 rule copy-area
   command = cp out/hierarchical_utilization_placed.rpt $out
 rule vivado
-  command = vivado -mode batch -source synth.tcl > /dev/null
+  command = XILINX_LOCAL_USER_DATA=no vivado -mode batch -source synth.tcl > /dev/null
 device_xdc = default.xdc
 build default.xdc: get-rsrc
 build synth.tcl: get-rsrc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-area-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-area-report.snap
@@ -20,7 +20,7 @@ rule copy-timing
 rule copy-area
   command = cp out/hierarchical_utilization_placed.rpt $out
 rule vivado
-  command = vivado -mode batch -source synth.tcl > /dev/null
+  command = XILINX_LOCAL_USER_DATA=no vivado -mode batch -source synth.tcl > /dev/null
 device_xdc = default.xdc
 build default.xdc: get-rsrc
 build synth.tcl: get-rsrc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-hierarchy-json.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-hierarchy-json.snap
@@ -20,7 +20,7 @@ rule copy-timing
 rule copy-area
   command = cp out/hierarchical_utilization_placed.rpt $out
 rule vivado
-  command = vivado -mode batch -source synth.tcl > /dev/null
+  command = XILINX_LOCAL_USER_DATA=no vivado -mode batch -source synth.tcl > /dev/null
 device_xdc = default.xdc
 build default.xdc: get-rsrc
 build synth.tcl: get-rsrc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-timing-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-timing-report.snap
@@ -20,7 +20,7 @@ rule copy-timing
 rule copy-area
   command = cp out/hierarchical_utilization_placed.rpt $out
 rule vivado
-  command = vivado -mode batch -source synth.tcl > /dev/null
+  command = XILINX_LOCAL_USER_DATA=no vivado -mode batch -source synth.tcl > /dev/null
 device_xdc = default.xdc
 build default.xdc: get-rsrc
 build synth.tcl: get-rsrc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-json.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-json.snap
@@ -20,7 +20,7 @@ rule copy-timing
 rule copy-area
   command = cp out/hierarchical_utilization_placed.rpt $out
 rule vivado
-  command = vivado -mode batch -source synth.tcl > /dev/null
+  command = XILINX_LOCAL_USER_DATA=no vivado -mode batch -source synth.tcl > /dev/null
 device_xdc = default.xdc
 build default.xdc: get-rsrc
 build synth.tcl: get-rsrc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-report.snap
@@ -20,7 +20,7 @@ rule copy-timing
 rule copy-area
   command = cp out/hierarchical_utilization_placed.rpt $out
 rule vivado
-  command = vivado -mode batch -source synth.tcl > /dev/null
+  command = XILINX_LOCAL_USER_DATA=no vivado -mode batch -source synth.tcl > /dev/null
 device_xdc = default.xdc
 build default.xdc: get-rsrc
 build synth.tcl: get-rsrc


### PR DESCRIPTION
Since updating Vivado, running multiple instances results in random failures. The problem seems to be the one described [here](https://adaptivesupport.amd.com/s/article/63253); I've added the fix from that article to the `fud2` op.