### PR TITLE
fix verilator tb: align with v5.050+ style requirements

### DIFF
--- a/fud2/rsrc/tb.sv
+++ b/fud2/rsrc/tb.sv
@@ -1,7 +1,11 @@
 module toplevel;
 
 // Signals for the main module.
-logic go, done, clk, reset;
+logic go = 1'd0;
+logic clk = 1'd0; 
+logic done ;
+logic reset = 1'd1;
+// , done, clk, reset;
 main #() main (
   .go(go),
   .clk(clk),
@@ -13,7 +17,7 @@ localparam RESET_CYCLES = 3;
 
 // Cycle counter. Make this signed to catch errors with cycle simulation
 // counts.
-logic signed [63:0] cycle_count;
+logic signed [63:0] cycle_count = 0;
 
 always_ff @(posedge clk) begin
   cycle_count <= cycle_count + 1;
@@ -55,10 +59,10 @@ initial begin
   end
 
   // Initial values
-  go = 0;
-  clk = 0;
-  reset = 1;
-  cycle_count = 0;
+  // go = 0;
+  // clk = 0;
+  // reset = 1;
+  // cycle_count = 0;
 
   forever begin
     #10 clk = ~clk;

--- a/fud2/rsrc/tb.sv
+++ b/fud2/rsrc/tb.sv
@@ -1,11 +1,11 @@
 module toplevel;
 
 // Signals for the main module.
+// include initial values
 logic go = 1'd0;
 logic clk = 1'd0; 
 logic done ;
 logic reset = 1'd1;
-// , done, clk, reset;
 main #() main (
   .go(go),
   .clk(clk),
@@ -58,11 +58,6 @@ initial begin
     $display("VCD tracing disabled");
   end
 
-  // Initial values
-  // go = 0;
-  // clk = 0;
-  // reset = 1;
-  // cycle_count = 0;
 
   forever begin
     #10 clk = ~clk;


### PR DESCRIPTION
not sure if this fixes all the problems that people had with verilator. just follows https://verilator.org/guide/latest/warnings.html#cmdoption-arg-MULTIDRIVEN (use a different approach to assigning initial values)