### PR TITLE
[Profiler] Statistics tables in Rusted Petal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "baa",
  "clap 4.6.1",
  "cranelift-entity 0.128.4",
+ "csv",
  "indexmap 2.14.0",
  "log",
  "prost",

--- a/runt.toml
+++ b/runt.toml
@@ -733,6 +733,8 @@ fud2 {} -o ${flame} --through rusted-petal-test -s sim.data={}.data --dir ${peta
 sort ${flame}
 echo =========
 cat ${petal_test_dir}/profiler-out/group-stats.csv
+echo =========
+cat ${petal_test_dir}/profiler-out/cell-stats.csv
 
 rm -rf ${petal_test_dir}
 """

--- a/runt.toml
+++ b/runt.toml
@@ -731,6 +731,8 @@ flame=${petal_test_dir}/flat-flame.folded && \
 fud2 {} -o ${flame} --through rusted-petal-test -s sim.data={}.data --dir ${petal_test_dir} 2> /dev/null
 
 sort ${flame}
+echo =========
+cat ${petal_test_dir}/profiler-out/group-stats.csv
 
 rm -rf ${petal_test_dir}
 """

--- a/tools/petal/Cargo.toml
+++ b/tools/petal/Cargo.toml
@@ -26,3 +26,4 @@ log.workspace = true
 indexmap.workspace = true
 prost = "0.14.4"
 rand = "0.10.2"
+csv.version = "1.4.0"

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -30,7 +30,7 @@ struct Cell {
     /// Ids of groups that could be called directly from this cell, if it is a component.
     /// NOTE: Primitive cells should have an empty vec here.
     groups: SmallVec<[GroupId; 6]>,
-    /// Control Registeres
+    /// Control Registers
     control_registers: SmallVec<[RegisterId; 6]>,
     /// The scope of the cell in the RTL trace.
     _scope: Option<ScopeRef>,
@@ -130,6 +130,8 @@ struct CRegister {
     name: String,
     write_en_signal_ref: SignalRef,
     in_signal_ref: SignalRef,
+    /// if the register is a pd, then this would be false.
+    is_fsm: bool,
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
@@ -171,7 +173,8 @@ pub struct CellControl {
     /// (ex. a component with a single-group control)
     toplevel_control: Option<ControlId>,
     /// Necessary for timeline view tracking (not used for constructing the call tree)
-    registers: Vec<String>,
+    fsms: Vec<String>,
+    pds: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -329,6 +332,22 @@ impl Design {
             .iter()
             .map(|(id, group)| (id, group.static_name()))
             .collect()
+    }
+
+    pub fn get_cell_name_fsm_count(&self) -> Vec<(CellId, String, u32)> {
+        let mut out: Vec<(CellId, String, u32)> = Vec::new();
+        for (id, cell) in self.cells.iter() {
+            if !cell.is_primitive {
+                let name = cell.display_name().to_string();
+                let fsm_count = cell
+                    .control_registers
+                    .iter()
+                    .filter(|&r| self.control_registers[*r].is_fsm)
+                    .count();
+                out.push((id, name, fsm_count as u32));
+            }
+        }
+        out
     }
 }
 
@@ -649,7 +668,8 @@ impl Design {
         let descriptors = c.descriptors(component);
         // let ctrl_map = descriptors.control_pos;
 
-        let mut registers = Vec::new();
+        let mut fsms = Vec::new();
+        let mut pds = Vec::new();
 
         // iterate through control par descriptors and construct Control nodes
         for (d, pos_set) in descriptors.control_pos.iter() {
@@ -663,8 +683,8 @@ impl Design {
                 let name = tdcc_info.name.clone();
 
                 match &tdcc_info.control_register {
-                    ControlRegister::Fsm(f) => registers.push(f.clone()),
-                    ControlRegister::Pd(p) => registers.append(&mut p.clone()),
+                    ControlRegister::Fsm(f) => fsms.push(f.clone()),
+                    ControlRegister::Pd(p) => pds.append(&mut p.clone()),
                 };
 
                 let ctrl_scope = get_scope(h, &h[s], &format!("{name}_go"))?;
@@ -733,7 +753,8 @@ impl Design {
         Ok(CellControl {
             group_to_parent,
             toplevel_control,
-            registers,
+            fsms,
+            pds,
         })
     }
 
@@ -810,23 +831,26 @@ impl Design {
         let CellControl {
             group_to_parent,
             toplevel_control,
-            registers,
+            fsms,
+            pds,
         } = self.populate_control(h, cell_scope, c, component)?;
         if let Some(top_ctrl) = toplevel_control {
             cell.control.push(top_ctrl);
         }
 
         // add entries for CRegisters
-        for register_scope in h[cell_scope]
-            .scopes(h)
-            .filter(|p| registers.contains(&h[*p].name(h).to_string()))
-        {
+        for register_scope in h[cell_scope].scopes(h).filter(|p| {
+            fsms.contains(&h[*p].name(h).to_string())
+                || pds.contains(&h[*p].name(h).to_string())
+        }) {
             let write_en_var = get_var(h, &h[register_scope], "write_en")?;
             let in_var = get_var(h, &h[register_scope], "in")?;
             let write_en_signal_ref = h[write_en_var].signal_ref();
             let in_signal_ref = h[in_var].signal_ref();
+            let name = h[register_scope].name(h).to_string();
             let register_id = self.control_registers.push(CRegister {
-                name: h[register_scope].name(h).to_string(),
+                is_fsm: fsms.contains(&name),
+                name,
                 write_en_signal_ref,
                 in_signal_ref,
             });

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -98,7 +98,7 @@ impl Group {
         format!(
             "{}.{}",
             self.component,
-            self.name.split("UG").next().unwrap().to_string()
+            self.name.split("UG").next().unwrap()
         )
     }
 }
@@ -116,7 +116,6 @@ struct Control {
     go_idx: u32,
     _pos: u32,
     pretty: String,
-    component: String,
 }
 
 impl Control {
@@ -342,14 +341,8 @@ impl Design {
 
     pub fn get_cell_name_fsm_count(
         &self,
-    ) -> Vec<(CellId, String, FxHashSet<RegisterId>, FxHashSet<RegisterId>)>
-    {
-        let mut out: Vec<(
-            CellId,
-            String,
-            FxHashSet<RegisterId>,
-            FxHashSet<RegisterId>,
-        )> = Vec::new();
+    ) -> Vec<(CellId, String, FxHashSet<RegisterId>)> {
+        let mut out: Vec<(CellId, String, FxHashSet<RegisterId>)> = Vec::new();
         for (id, cell) in self.cells.iter() {
             if !cell.is_primitive {
                 let name = cell.stats_name().to_string();
@@ -362,7 +355,7 @@ impl Design {
                         pds.insert(*r);
                     }
                 }
-                out.push((id, name, fsms, pds));
+                out.push((id, name, fsms));
             }
         }
         out
@@ -737,7 +730,6 @@ impl Design {
                     go_idx: u32::MAX,
                     _pos: pos,
                     pretty,
-                    component: component.to_string(),
                 };
                 let ctrl_id = self.controls.push(ctrl);
                 pos_to_id.insert(pos, ctrl_id);

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -78,13 +78,23 @@ struct Group {
     probe: SignalRef,
     invokes: SmallVec<[InvokeId; 6]>,
     probe_idx: u32,
+    component: String,
 }
 
 impl Group {
-    /// String representation of cell for trace and visualizations
+    /// String representation of group for trace and visualizations
     pub fn display_name(&self) -> String {
         // remove unique group identifier.
         self.name.split("UG").next().unwrap().to_string()
+    }
+
+    /// String representation of group for stats
+    pub fn static_name(&self) -> String {
+        format!(
+            "{}.{}",
+            self.component,
+            self.name.split("UG").next().unwrap().to_string()
+        )
     }
 }
 
@@ -101,6 +111,7 @@ struct Control {
     go_idx: u32,
     _pos: u32,
     pretty: String,
+    component: String,
 }
 
 impl Control {
@@ -311,6 +322,13 @@ impl Design {
         par_tracks: &FxHashMap<String, FxHashMap<String, u32>>,
     ) -> Result<()> {
         self.build_cell_timeline_tracks(&self.main, t, par_tracks)
+    }
+
+    pub fn get_group_component_names(&self) -> Vec<(GroupId, String)> {
+        self.groups
+            .iter()
+            .map(|(id, group)| (id, group.static_name()))
+            .collect()
     }
 }
 
@@ -660,6 +678,7 @@ impl Design {
                     go_idx: u32::MAX,
                     _pos: pos,
                     pretty,
+                    component: component.to_string(),
                 };
                 let ctrl_id = self.controls.push(ctrl);
                 pos_to_id.insert(pos, ctrl_id);
@@ -861,6 +880,7 @@ impl Design {
                                 probe,
                                 invokes,
                                 probe_idx: u32::MAX,
+                                component: component.to_string(),
                             });
                             all_groups.push(group_id);
                             structurally_invoked_group_names
@@ -922,6 +942,7 @@ impl Design {
                                 probe,
                                 invokes,
                                 probe_idx: u32::MAX,
+                                component: component.to_string(),
                             });
                             if let Some(Some(ctrl_parent)) =
                                 group_to_parent.get(&name)

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -65,6 +65,11 @@ impl Cell {
             format!("{} [{}]", self.name, self.component)
         }
     }
+
+    pub fn stats_name(&self) -> String {
+        assert!(!self.is_primitive);
+        format!("{} [{}]", self.full_path, self.component)
+    }
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
@@ -347,7 +352,7 @@ impl Design {
         )> = Vec::new();
         for (id, cell) in self.cells.iter() {
             if !cell.is_primitive {
-                let name = cell.display_name().to_string();
+                let name = cell.stats_name().to_string();
                 let mut fsms: FxHashSet<RegisterId> = FxHashSet::default();
                 let mut pds: FxHashSet<RegisterId> = FxHashSet::default();
                 for r in cell.control_registers.iter() {

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, anyhow};
 use baa::{BitVecOps, BitVecValue};
 use core::panic;
 use cranelift_entity::{PrimaryMap, entity_impl};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec};
 use wellen::{Hierarchy, Scope, ScopeRef, SignalRef, VarRef};
 
@@ -298,15 +298,16 @@ impl Design {
     pub fn compute_cycle_trace(
         &self,
         values: &BitVecValue,
-    ) -> Result<(Vec<Stack>, CurrentlyActive)> {
+    ) -> Result<(Vec<Stack>, CurrentlyActive, bool)> {
         let main = &self.cells[self.main];
         let (main_go, main_done) = main.probe_idxs.unwrap();
         let main_active =
             values.is_bit_set(main_go) & !values.is_bit_set(main_done);
         let mut stacks = vec![];
+        let mut group_or_primitive_leaf: bool = false;
         let mut current_active = CurrentlyActive::new();
         if main_active {
-            stacks = self.find_active_from_cell(
+            (stacks, group_or_primitive_leaf) = self.find_active_from_cell(
                 values,
                 self.main,
                 vec![],
@@ -315,7 +316,7 @@ impl Design {
             stacks.sort();
             stacks.dedup();
         }
-        Ok((stacks, current_active))
+        Ok((stacks, current_active, group_or_primitive_leaf))
     }
 
     /// Constructs the tracks in the timeline view
@@ -334,17 +335,29 @@ impl Design {
             .collect()
     }
 
-    pub fn get_cell_name_fsm_count(&self) -> Vec<(CellId, String, u32)> {
-        let mut out: Vec<(CellId, String, u32)> = Vec::new();
+    pub fn get_cell_name_fsm_count(
+        &self,
+    ) -> Vec<(CellId, String, FxHashSet<RegisterId>, FxHashSet<RegisterId>)>
+    {
+        let mut out: Vec<(
+            CellId,
+            String,
+            FxHashSet<RegisterId>,
+            FxHashSet<RegisterId>,
+        )> = Vec::new();
         for (id, cell) in self.cells.iter() {
             if !cell.is_primitive {
                 let name = cell.display_name().to_string();
-                let fsm_count = cell
-                    .control_registers
-                    .iter()
-                    .filter(|&r| self.control_registers[*r].is_fsm)
-                    .count();
-                out.push((id, name, fsm_count as u32));
+                let mut fsms: FxHashSet<RegisterId> = FxHashSet::default();
+                let mut pds: FxHashSet<RegisterId> = FxHashSet::default();
+                for r in cell.control_registers.iter() {
+                    if self.control_registers[*r].is_fsm {
+                        fsms.insert(*r);
+                    } else {
+                        pds.insert(*r);
+                    }
+                }
+                out.push((id, name, fsms, pds));
             }
         }
         out
@@ -401,16 +414,18 @@ pub fn parse_probe_name(name: &str) -> Result<ProbeName<'_>> {
 pub type Stack = Vec<String>;
 
 impl Design {
-    /// Builds up all active tree paths this cycle from the cell of cell_id.
+    /// Builds up all active tree paths this cycle from the component cell of cell_id.
     /// prefix is the state of the stack before this particular cell.
-    /// NOTE: This function is co-recursive with compute_group().
+    /// Returns: The active call tree and a flag indicating whether there was a leaf (last element of a stack)
+    /// that is a group or primitive (used to classify cells for `staticstics::CellStats`).
+    /// NOTE: This function is co-recursive with `find_active_from_control()` and `find_active_from_group()`.
     fn find_active_from_cell(
         &self,
         value: &BitVecValue,
         cell_id: CellId,
         mut prefix: Stack,
         active_this_cycle: &mut CurrentlyActive,
-    ) -> Vec<Stack> {
+    ) -> (Vec<Stack>, bool) {
         let cell = &self.cells[cell_id];
         active_this_cycle.add_active_cell(cell_id);
         if let Some((main_go_idx, main_done_idx)) = cell.probe_idxs {
@@ -419,36 +434,39 @@ impl Design {
             {
                 prefix.push(cell.display_name());
             } else {
-                return vec![prefix];
+                return (vec![prefix], false);
             }
         }
         if cell.groups.is_empty() && cell.control.is_empty() {
             // No more children, so this is a sink.
-            return vec![prefix];
+            return (vec![prefix], false);
         }
         let mut out = vec![];
+        let mut group_primitive_leaf = false;
         for &group_idx in &cell.groups {
             let group = &self.groups[group_idx];
             if value.is_bit_set(group.probe_idx) {
-                let mut group_stacks = self.find_active_from_group(
+                let (mut group_stacks, flag) = self.find_active_from_group(
                     value,
                     group_idx,
                     prefix.clone(),
                     active_this_cycle,
                 );
                 out.append(&mut group_stacks);
+                group_primitive_leaf |= flag;
             }
         }
         for &control_idx in &cell.control {
             let control = &self.controls[control_idx];
             if value.is_bit_set(control.go_idx) {
-                let mut control_stacks = self.find_active_from_control(
+                let (mut control_stacks, flag) = self.find_active_from_control(
                     value,
                     control_idx,
                     prefix.clone(),
                     active_this_cycle,
                 );
                 out.append(&mut control_stacks);
+                group_primitive_leaf |= flag;
             }
         }
 
@@ -458,11 +476,13 @@ impl Design {
             out.push(prefix);
         }
 
-        out
+        (out, group_primitive_leaf)
     }
 
     /// Builds up all active tree paths this cycle from the group of group_id.
     /// prefix is the state of the stack before this particular group.
+    /// Returns: The active call tree and a flag indicating whether there was a leaf (last element of a stack)
+    /// that is a group or primitive (used to classify cells for `staticstics::CellStats`).
     /// NOTE: This function is co-recursive with compute_cell(), and only called when
     /// the control group is active (otherwise this function would not be called.)
     fn find_active_from_control(
@@ -471,14 +491,14 @@ impl Design {
         control_id: ControlId,
         mut prefix: Stack,
         active_this_cycle: &mut CurrentlyActive,
-    ) -> Vec<Stack> {
+    ) -> (Vec<Stack>, bool) {
         let control = &self.controls[control_id];
         prefix.push(control.display_name());
         active_this_cycle.add_active_control(control_id);
-        if control.invokes.is_empty() {
-            return vec![prefix];
-        }
+        // it probably wouldn't make any sense for a control to not contain any invokes?
+        assert!(!control.invokes.is_empty());
         let mut out = vec![];
+        let mut group_primitive_leaf = false;
         for &invoke_id in &control.invokes {
             let invoke = &self.invokes[invoke_id];
             if value.is_bit_set(invoke.probe_idx) {
@@ -490,22 +510,26 @@ impl Design {
                         )
                     }
                     InvokeTarget::Group(target_group_id) => {
-                        let mut group_stacks = self.find_active_from_group(
-                            value,
-                            target_group_id,
-                            prefix.clone(),
-                            active_this_cycle,
-                        );
+                        let (mut group_stacks, flag) = self
+                            .find_active_from_group(
+                                value,
+                                target_group_id,
+                                prefix.clone(),
+                                active_this_cycle,
+                            );
                         out.append(&mut group_stacks);
+                        group_primitive_leaf |= flag;
                     }
                     InvokeTarget::Control(target_control_id) => {
-                        let mut control_stacks = self.find_active_from_control(
-                            value,
-                            target_control_id,
-                            prefix.clone(),
-                            active_this_cycle,
-                        );
+                        let (mut control_stacks, flag) = self
+                            .find_active_from_control(
+                                value,
+                                target_control_id,
+                                prefix.clone(),
+                                active_this_cycle,
+                            );
                         out.append(&mut control_stacks);
+                        group_primitive_leaf |= flag;
                     }
                 }
             }
@@ -517,11 +541,13 @@ impl Design {
             out.push(prefix);
         }
 
-        out
+        (out, group_primitive_leaf)
     }
 
     /// Builds up all active tree paths this cycle from the group of group_id.
     /// prefix is the state of the stack before this particular group.
+    /// Returns: The active call tree and a flag indicating whether there was a leaf (last element of a stack)
+    /// that is a group or primitive (used to classify cells for `staticstics::CellStats`).
     /// NOTE: This function is co-recursive with compute_cell() and compute_control(), and only called when
     /// the group is active (otherwise this function would not be called.)
     fn find_active_from_group(
@@ -530,14 +556,16 @@ impl Design {
         group_id: GroupId,
         mut prefix: Stack,
         active_this_cycle: &mut CurrentlyActive,
-    ) -> Vec<Stack> {
+    ) -> (Vec<Stack>, bool) {
         let group = &self.groups[group_id];
         prefix.push(group.display_name());
         active_this_cycle.add_active_group(group_id);
         if group.invokes.is_empty() {
-            return vec![prefix];
+            // this group is a leaf, since it does not invoke anything.
+            return (vec![prefix], true);
         }
         let mut out: Vec<Stack> = vec![];
+        let mut group_or_primitive_leaf = false;
         for &invoke_id in &group.invokes {
             let mut this_thread_prefix = prefix.clone();
             let invoke = &self.invokes[invoke_id];
@@ -550,25 +578,31 @@ impl Design {
                         this_thread_prefix.push(target_cell.display_name());
                         if target_cell.is_primitive {
                             out.push(this_thread_prefix);
+                            // A primitive will always be a leaf as it cannot call anything else.
+                            group_or_primitive_leaf = true;
                         } else {
-                            let mut cell_stacks = self.find_active_from_cell(
-                                value,
-                                target_cell_id,
-                                this_thread_prefix.clone(),
-                                active_this_cycle,
-                            );
+                            let (mut cell_stacks, flag) = self
+                                .find_active_from_cell(
+                                    value,
+                                    target_cell_id,
+                                    this_thread_prefix.clone(),
+                                    active_this_cycle,
+                                );
                             out.append(&mut cell_stacks);
+                            group_or_primitive_leaf |= flag;
                         }
                     }
                     InvokeTarget::Group(target_group_id) => {
                         // structural enable (group enables another group)
-                        let mut group_stacks = self.find_active_from_group(
-                            value,
-                            target_group_id,
-                            this_thread_prefix.clone(),
-                            active_this_cycle,
-                        );
+                        let (mut group_stacks, flag) = self
+                            .find_active_from_group(
+                                value,
+                                target_group_id,
+                                this_thread_prefix.clone(),
+                                active_this_cycle,
+                            );
                         out.append(&mut group_stacks);
+                        group_or_primitive_leaf |= flag;
                     }
                     InvokeTarget::Control(_) => {
                         panic!("Group should not invoke a Control node!")
@@ -576,7 +610,7 @@ impl Design {
                 }
             }
         }
-        out
+        (out, group_or_primitive_leaf)
     }
 
     /// Maps between probes and their indices in self.signals().

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -8,8 +8,10 @@ mod visuals;
 #[allow(clippy::all)]
 #[rustfmt::skip]
 mod perfetto_protos;
+mod statistics;
 
 use crate::design::{Design, RegisterId, Stack};
+use crate::statistics::Statistics;
 use crate::timeline::{CurrentlyActive, Timeline};
 use crate::visuals::{compute_flame, write_flame};
 use anyhow::{Context, Ok, Result, anyhow};
@@ -57,6 +59,7 @@ fn collect_stacks(
 ) -> Result<Stacks> {
     // Compute the trace (stacks for each active cycle) from probe_values
     let mut out: Stacks = IndexMap::default();
+    let mut currently_active = CurrentlyActive::default();
     for (cycle_count, value) in probe_values.iter().enumerate() {
         let active_this_cycle = if let Some((count, _s, active)) =
             out.get_mut(value)
@@ -69,12 +72,22 @@ fn collect_stacks(
             out.insert(value.clone(), (1, stacks, active_this_cycle.clone()));
             &mut active_this_cycle.clone()
         };
-        timeline.update_timeline(active_this_cycle, cycle_count as u64)?;
+        // get cell/control/group activity information
+        let (ended, started) = currently_active.resolve(active_this_cycle)?;
+        currently_active = active_this_cycle.clone();
+        timeline.update_timeline(&started, &ended, cycle_count as u64)?;
     }
     // close out the timeline view
-    let end = CurrentlyActive::new();
-    timeline.update_timeline(&end, probe_values.len() as u64)?;
+    timeline.update_timeline(
+        &CurrentlyActive::new(),
+        &currently_active,
+        probe_values.len() as u64,
+    )?;
     Ok(out)
+}
+
+fn build_statistics(d: Design) -> Result<Statistics> {
+    Ok(Statistics::new(d.get_group_component_names()))
 }
 
 fn print_stacks(

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -11,7 +11,7 @@ mod perfetto_protos;
 mod statistics;
 
 use crate::design::{Design, RegisterId, Stack};
-use crate::statistics::Statistics;
+use crate::statistics::{CycleType, Statistics};
 use crate::timeline::{CurrentlyActive, Timeline};
 use crate::visuals::{compute_flame, write_flame};
 use anyhow::{Context, Ok, Result, anyhow};
@@ -50,39 +50,58 @@ struct Args {
     num_print_cycles: u64,
 }
 
-pub type Stacks = IndexMap<BitVecValue, (u64, Vec<Stack>, CurrentlyActive)>;
+/// bool flag represents whether this cycle contained an active Group or Primitive leaf.
+pub type Stacks =
+    IndexMap<BitVecValue, (u64, Vec<Stack>, CurrentlyActive, bool)>;
 
 fn collect_stacks(
     design: &Design,
     timeline: &mut Timeline,
     stats: &mut Statistics,
     probe_values: &[BitVecValue],
+    register_value_diffs: &FxHashMap<u64, FxHashMap<RegisterId, u64>>,
 ) -> Result<Stacks> {
     // Compute the trace (stacks for each active cycle) from probe_values
     let mut out: Stacks = IndexMap::default();
     let mut currently_active = CurrentlyActive::default();
     for (cycle_count, value) in probe_values.iter().enumerate() {
-        let active_this_cycle = if let Some((count, _s, active)) =
-            out.get_mut(value)
-        {
-            *count += 1;
-            active
-        } else {
-            let (stacks, active_this_cycle) =
-                design.compute_cycle_trace(value)?;
-            out.insert(value.clone(), (1, stacks, active_this_cycle.clone()));
-            &mut active_this_cycle.clone()
-        };
+        let (active_this_cycle, gp_flag) =
+            if let Some((count, _s, active, gp_flag)) = out.get_mut(value) {
+                *count += 1;
+                (active, gp_flag.clone())
+            } else {
+                let (stacks, active_this_cycle, group_or_primitive_leaf) =
+                    design.compute_cycle_trace(value)?;
+                out.insert(
+                    value.clone(),
+                    (
+                        1,
+                        stacks,
+                        active_this_cycle.clone(),
+                        group_or_primitive_leaf,
+                    ),
+                );
+                (&mut active_this_cycle.clone(), group_or_primitive_leaf)
+            };
+
         // get cell/control/group activity information
         let (started, ended) = currently_active.resolve(active_this_cycle)?;
         currently_active = active_this_cycle.clone();
         timeline.update(&started, &ended, cycle_count as u64)?;
-        stats.update(&started, &ended, cycle_count as u64);
+        stats.update(
+            &started,
+            &ended,
+            cycle_count as u64,
+            gp_flag,
+            &register_value_diffs,
+            currently_active.get_active_cells(),
+        );
     }
     // close out timeline view/statistics by "ending" the contents of `currently_active`.
     let empty = CurrentlyActive::new();
-    timeline.update(&empty, &currently_active, probe_values.len() as u64)?;
-    stats.update(&empty, &currently_active, probe_values.len() as u64);
+    let total_cycles = probe_values.len() as u64;
+    timeline.update(&empty, &currently_active, total_cycles)?;
+    stats.close(&currently_active, total_cycles);
 
     Ok(out)
 }
@@ -90,7 +109,7 @@ fn collect_stacks(
 fn build_statistics(d: &Design) -> Result<Statistics> {
     let g = d.get_group_component_names();
     let c = d.get_cell_name_fsm_count();
-    Ok(Statistics::new())
+    Ok(Statistics::new(g, c))
 }
 
 fn print_stacks(
@@ -239,8 +258,13 @@ fn main() -> Result<()> {
     })?;
     println!("Number of cycles: {}", probe_values.len());
 
-    let stacks =
-        collect_stacks(&design, &mut timeline, &mut statistics, &probe_values)?;
+    let stacks = collect_stacks(
+        &design,
+        &mut timeline,
+        &mut statistics,
+        &probe_values,
+        &register_value_diffs,
+    )?;
     print_stacks(&probe_values, &stacks, args.num_print_cycles);
     let flame_info = compute_flame(&stacks)?;
     write_flame(&flame_info, args.scaled_flame_out, args.flat_flame_out)?;

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -65,10 +65,10 @@ fn collect_stacks(
     let mut out: Stacks = IndexMap::default();
     let mut currently_active = CurrentlyActive::default();
     for (cycle_count, value) in probe_values.iter().enumerate() {
-        let (active_this_cycle, gp_flag) =
+        let (active_this_cycle, gp_flag): (&mut CurrentlyActive, bool) =
             if let Some((count, _s, active, gp_flag)) = out.get_mut(value) {
                 *count += 1;
-                (active, gp_flag.clone())
+                (active, *gp_flag)
             } else {
                 let (stacks, active_this_cycle, group_or_primitive_leaf) =
                     design.compute_cycle_trace(value)?;
@@ -93,7 +93,7 @@ fn collect_stacks(
             &ended,
             cycle_count as u64,
             gp_flag,
-            &register_value_diffs,
+            register_value_diffs,
             currently_active.get_active_cells(),
         );
     }

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -88,7 +88,9 @@ fn collect_stacks(
 }
 
 fn build_statistics(d: &Design) -> Result<Statistics> {
-    Ok(Statistics::new(d.get_group_component_names()))
+    let g = d.get_group_component_names();
+    let c = d.get_cell_name_fsm_count();
+    Ok(Statistics::new())
 }
 
 fn print_stacks(

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -55,6 +55,7 @@ pub type Stacks = IndexMap<BitVecValue, (u64, Vec<Stack>, CurrentlyActive)>;
 fn collect_stacks(
     design: &Design,
     timeline: &mut Timeline,
+    stats: &mut Statistics,
     probe_values: &[BitVecValue],
 ) -> Result<Stacks> {
     // Compute the trace (stacks for each active cycle) from probe_values
@@ -73,20 +74,20 @@ fn collect_stacks(
             &mut active_this_cycle.clone()
         };
         // get cell/control/group activity information
-        let (ended, started) = currently_active.resolve(active_this_cycle)?;
+        let (started, ended) = currently_active.resolve(active_this_cycle)?;
         currently_active = active_this_cycle.clone();
-        timeline.update_timeline(&started, &ended, cycle_count as u64)?;
+        timeline.update(&started, &ended, cycle_count as u64)?;
+        stats.update(&started, &ended, cycle_count as u64);
     }
-    // close out the timeline view
-    timeline.update_timeline(
-        &CurrentlyActive::new(),
-        &currently_active,
-        probe_values.len() as u64,
-    )?;
+    // close out timeline view/statistics by "ending" the contents of `currently_active`.
+    let empty = CurrentlyActive::new();
+    timeline.update(&empty, &currently_active, probe_values.len() as u64)?;
+    stats.update(&empty, &currently_active, probe_values.len() as u64);
+
     Ok(out)
 }
 
-fn build_statistics(d: Design) -> Result<Statistics> {
+fn build_statistics(d: &Design) -> Result<Statistics> {
     Ok(Statistics::new(d.get_group_component_names()))
 }
 
@@ -138,6 +139,7 @@ fn main() -> Result<()> {
     let par_tracks = timeline::read_par_tracks(args.par_tracks_filename)?;
     let mut timeline = Timeline::new()?;
     design.build_timeline_tracks(&mut timeline, &par_tracks)?;
+    let mut statistics = build_statistics(&design)?;
 
     // all probe signals we would need to track
     let signals = design.get_signals();
@@ -235,7 +237,8 @@ fn main() -> Result<()> {
     })?;
     println!("Number of cycles: {}", probe_values.len());
 
-    let stacks = collect_stacks(&design, &mut timeline, &probe_values)?;
+    let stacks =
+        collect_stacks(&design, &mut timeline, &mut statistics, &probe_values)?;
     print_stacks(&probe_values, &stacks, args.num_print_cycles);
     let flame_info = compute_flame(&stacks)?;
     write_flame(&flame_info, args.scaled_flame_out, args.flat_flame_out)?;
@@ -245,6 +248,7 @@ fn main() -> Result<()> {
     )?;
 
     timeline.output_timeline(&args.out_dir)?;
+    statistics.output(&args.out_dir)?;
 
     Ok(())
 }

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -11,7 +11,7 @@ mod perfetto_protos;
 mod statistics;
 
 use crate::design::{Design, RegisterId, Stack};
-use crate::statistics::{CycleType, Statistics};
+use crate::statistics::Statistics;
 use crate::timeline::{CurrentlyActive, Timeline};
 use crate::visuals::{compute_flame, write_flame};
 use anyhow::{Context, Ok, Result, anyhow};

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -172,6 +172,8 @@ fn main() -> Result<()> {
         signals_to_track.push(*in_signal);
     }
     let filter = wellen::stream::Filter::include_signals(&signals_to_track);
+    let probe_signal_set: FxHashSet<SignalRef> =
+        signals.iter().copied().collect();
 
     let mut clock_previous = true;
 
@@ -205,7 +207,6 @@ fn main() -> Result<()> {
             let main_done: bool =
                 values.get(&main_done_ref).unwrap().try_into().unwrap();
             if main_go && !main_done {
-                let mut processed = FxHashSet::default();
                 // first process the register write_ens and ins
                 for changed_write_en in changed
                     .iter()
@@ -221,11 +222,9 @@ fn main() -> Result<()> {
                         control_register_diffs
                             .insert(*register_id, register_new_value);
                     }
-                    processed.insert(changed_write_en);
-                    processed.insert(in_signal);
                 }
                 for signal in
-                    changed.iter().filter(|&s| !processed.contains(&s))
+                    changed.iter().filter(|&s| probe_signal_set.contains(s))
                 {
                     // normal probe values
                     let probe_value: bool = values

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -1,9 +1,12 @@
 use crate::design::{CellId, GroupId};
 use crate::timeline::CurrentlyActive;
+use anyhow::{Context, Ok, Result, anyhow};
 use cranelift_entity::SecondaryMap;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::fs::File;
+use std::path::PathBuf;
 
 /// Output Group stats CSV table
 #[derive(Debug, Clone, Serialize)]
@@ -48,7 +51,7 @@ impl GroupStats {
     pub fn group_end(&mut self, cycle: u64) {
         assert!(self.curr_start.is_some());
         let start = self.curr_start.unwrap();
-        let length = cycle - start - 1;
+        let length = cycle - start;
         if length > self.max {
             self.max = length;
         }
@@ -108,7 +111,7 @@ impl Statistics {
         Self { group_to_stats }
     }
 
-    pub fn resolve(
+    pub fn update(
         &mut self,
         started: &CurrentlyActive,
         ended: &CurrentlyActive,
@@ -121,16 +124,21 @@ impl Statistics {
         }
 
         // process all groups that ended
+        for ended_group in ended.get_active_groups() {
+            assert!(self.group_to_stats.get(*ended_group).is_some());
+            self.group_to_stats[*ended_group].group_end(cycle);
+        }
     }
 
-    pub fn group_begin(&mut self, group: &GroupId, cycle: u64) {
-        let stat = &mut self.group_to_stats[*group];
-        stat.group_start(cycle);
-    }
+    pub fn output(&self, out_dir: &str) -> Result<()> {
+        let mut path = PathBuf::from(out_dir);
+        path.push("group-stats.csv");
+        let mut file = File::create(path)?;
 
-    pub fn group_end(&mut self, group: &GroupId, cycle: u64) {
-        assert!(self.group_to_stats.get(*group).is_some());
-        let stat = &mut self.group_to_stats[*group];
-        stat.group_end(cycle);
+        let mut writer = csv::Writer::from_writer(file);
+        for (_id, stats) in self.group_to_stats.iter() {
+            writer.serialize(stats.convert_to_csv_struct())?;
+        }
+        Ok(())
     }
 }

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -21,7 +21,7 @@ struct GroupStatsOut {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct GroupStats {
+struct GroupStats {
     name: String,
     num_times_active: u64,
     total_cycles: u64,
@@ -133,11 +133,22 @@ impl Statistics {
     pub fn output(&self, out_dir: &str) -> Result<()> {
         let mut path = PathBuf::from(out_dir);
         path.push("group-stats.csv");
-        let mut file = File::create(path)?;
+        let file = File::create(path)?;
 
         let mut writer = csv::Writer::from_writer(file);
-        for (_id, stats) in self.group_to_stats.iter() {
-            writer.serialize(stats.convert_to_csv_struct())?;
+        // serialize in sorted order of groups' static name.
+        let name_to_stats_csv: FxHashMap<String, GroupStatsOut> = self
+            .group_to_stats
+            .iter()
+            .map(|(_, stats)| {
+                (stats.name.clone(), stats.convert_to_csv_struct())
+            })
+            .collect();
+        let mut sorted_names: Vec<String> =
+            name_to_stats_csv.keys().cloned().collect();
+        sorted_names.sort();
+        for name in sorted_names {
+            writer.serialize(name_to_stats_csv[&name].clone())?;
         }
         Ok(())
     }

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -1,0 +1,136 @@
+use crate::design::{CellId, GroupId};
+use crate::timeline::CurrentlyActive;
+use cranelift_entity::SecondaryMap;
+use rustc_hash::FxHashMap;
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Output Group stats CSV table
+#[derive(Debug, Clone, Serialize)]
+struct GroupStatsOut {
+    name: String,
+    num_times_active: u64,
+    total_cycles: u64,
+    min: u64,
+    max: u64,
+    avg: f64,
+    can_static: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GroupStats {
+    name: String,
+    num_times_active: u64,
+    total_cycles: u64,
+    min: u64,
+    max: u64,
+    // the start cycle of this "span", if there exists one.
+    curr_start: Option<u64>,
+}
+
+impl GroupStats {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            num_times_active: 0,
+            total_cycles: 0,
+            min: u64::MAX,
+            max: u64::MIN,
+            curr_start: None,
+        }
+    }
+
+    pub fn group_start(&mut self, cycle: u64) {
+        assert!(self.curr_start.is_none());
+        self.curr_start = Some(cycle);
+    }
+
+    pub fn group_end(&mut self, cycle: u64) {
+        assert!(self.curr_start.is_some());
+        let start = self.curr_start.unwrap();
+        let length = cycle - start - 1;
+        if length > self.max {
+            self.max = length;
+        }
+        if length < self.min {
+            self.min = length;
+        }
+        self.num_times_active += 1;
+        self.total_cycles += length;
+
+        self.curr_start = None;
+    }
+
+    pub fn convert_to_csv_struct(&self) -> GroupStatsOut {
+        let avg = self.num_times_active as f64 / self.total_cycles as f64;
+        let can_static = self.max == self.min;
+        GroupStatsOut {
+            name: self.name.clone(),
+            total_cycles: self.total_cycles,
+            min: self.min,
+            max: self.max,
+            num_times_active: self.num_times_active,
+            avg,
+            can_static,
+        }
+    }
+}
+
+/// Output Cell stats CSV table
+#[derive(Debug, Clone, Serialize)]
+struct CellStatsOut {
+    name: String,
+    num_fsms: u32,
+    total_cycles: u64,
+    times_active: u64,
+    avg: f64,
+    useful_cycles: u64,
+    useful_cycles_percent: f64,
+    group_or_primitive: f64,
+    fsm_update: f64,
+    pd_update: f64,
+    other: f64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Statistics {
+    group_to_stats: SecondaryMap<GroupId, GroupStats>,
+    // cell_to_stats: SecondaryMap<CellId, CellStats>,
+}
+
+impl Statistics {
+    pub fn new(group_to_names: Vec<(GroupId, String)>) -> Self {
+        let group_to_stats = SecondaryMap::from_iter(
+            group_to_names
+                .into_iter()
+                .map(|(group_id, name)| (group_id, GroupStats::new(name))),
+        );
+        Self { group_to_stats }
+    }
+
+    pub fn resolve(
+        &mut self,
+        started: &CurrentlyActive,
+        ended: &CurrentlyActive,
+        cycle: u64,
+    ) {
+        // process all groups that started
+        for started_group in started.get_active_groups() {
+            assert!(self.group_to_stats.get(*started_group).is_some());
+            self.group_to_stats[*started_group].group_start(cycle);
+        }
+
+        // process all groups that ended
+    }
+
+    pub fn group_begin(&mut self, group: &GroupId, cycle: u64) {
+        let stat = &mut self.group_to_stats[*group];
+        stat.group_start(cycle);
+    }
+
+    pub fn group_end(&mut self, group: &GroupId, cycle: u64) {
+        assert!(self.group_to_stats.get(*group).is_some());
+        let stat = &mut self.group_to_stats[*group];
+        stat.group_end(cycle);
+    }
+}

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -217,13 +217,17 @@ impl Statistics {
             FxHashSet<RegisterId>,
         )>,
     ) -> Self {
-        let fsms: FxHashSet<RegisterId> = FxHashSet::default();
-        let pds: FxHashSet<RegisterId> = FxHashSet::default();
+        let mut fsms: FxHashSet<RegisterId> = FxHashSet::default();
+        let mut pds: FxHashSet<RegisterId> = FxHashSet::default();
         let group_to_stats = SecondaryMap::from_iter(
             group_to_names
                 .into_iter()
                 .map(|(group_id, name)| (group_id, GroupStats::new(name))),
         );
+        for (_, _, f, p) in cell_info.iter() {
+            fsms.extend(f);
+            pds.extend(p);
+        }
         let cell_to_stats = SecondaryMap::from_iter(cell_info.into_iter().map(
             |(cell_id, name, fsms, pds)| (cell_id, CellStats::new(name, fsms)),
         ));

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -1,10 +1,9 @@
 use crate::design::{CellId, GroupId, RegisterId};
 use crate::timeline::CurrentlyActive;
-use anyhow::{Context, Ok, Result, anyhow};
+use anyhow::{Ok, Result};
 use cranelift_entity::SecondaryMap;
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde::Serialize;
-use std::collections::HashMap;
+use serde::{Serialize, Serializer};
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -79,6 +78,15 @@ impl GroupStats {
     }
 }
 
+fn format_float<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let rounded = (value * 100.0).round() / 100.0;
+    let s = format!("{:.2}", rounded);
+    serializer.serialize_str(&s)
+}
+
 /// Output Cell stats CSV table
 #[derive(Debug, Clone, Serialize)]
 struct CellStatsOut {
@@ -86,12 +94,18 @@ struct CellStatsOut {
     num_fsms: u32,
     total_cycles: u64,
     times_active: u64,
+    #[serde(serialize_with = "format_float")]
     avg: f64,
     useful_cycles: u64,
+    #[serde(serialize_with = "format_float")]
     useful_cycles_percent: f64,
+    #[serde(serialize_with = "format_float")]
     group_or_primitive: f64,
+    #[serde(serialize_with = "format_float")]
     fsm_update: f64,
+    #[serde(serialize_with = "format_float")]
     pd_update: f64,
+    #[serde(serialize_with = "format_float")]
     other: f64,
 }
 
@@ -104,7 +118,7 @@ pub enum CycleType {
     Other,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
 struct CellStats {
     name: String,
     num_fsms: u32,
@@ -134,6 +148,7 @@ impl CellStats {
         s.type_to_num_cycles.insert(CycleType::FsmUpdate, 0);
         s.type_to_num_cycles.insert(CycleType::PdUpdate, 0);
         s.type_to_num_cycles.insert(CycleType::Other, 0);
+        println!("Cell stats: {s:?}");
         s
     }
 
@@ -149,12 +164,12 @@ impl CellStats {
     }
 
     pub fn convert_to_csv_struct(&self) -> CellStatsOut {
-        let avg = self.num_fsms as f64 / self.total_cycles as f64;
+        let avg = self.total_cycles as f64 / self.times_active as f64;
         let useful_cycles = self.type_to_num_cycles
             [&CycleType::GroupOrPrimitive]
             + self.type_to_num_cycles[&CycleType::Other];
         let useful_cycles_percent =
-            (useful_cycles as f64) / (self.total_cycles as f64);
+            ((useful_cycles as f64) / (self.total_cycles as f64)) * 100.0;
         let group_or_primitive =
             self.get_type_percent(CycleType::GroupOrPrimitive);
         let fsm_update = self.get_type_percent(CycleType::FsmUpdate);
@@ -180,7 +195,7 @@ impl CellStats {
 impl CellStats {
     fn get_type_percent(&self, t: CycleType) -> f64 {
         let count = self.type_to_num_cycles[&t] as f64;
-        count / self.total_cycles as f64
+        (count / self.total_cycles as f64) * 100.0
     }
 }
 
@@ -242,7 +257,7 @@ impl Statistics {
         }
 
         let cycle_type =
-            self.classify_cycle(gp_flag, &register_value_diffs[&cycle]);
+            self.classify_cycle(gp_flag, &register_value_diffs.get(&cycle));
         for cell in active_cells {
             let started_now = started.get_active_cells().contains(cell);
             self.cell_to_stats[*cell]
@@ -276,6 +291,7 @@ impl Statistics {
         let name_to_stats_csv: FxHashMap<String, CellStatsOut> = self
             .cell_to_stats
             .iter()
+            .filter(|(_, stats)| **stats != CellStats::default())
             .map(|(_, stats)| {
                 (stats.name.clone(), stats.convert_to_csv_struct())
             })
@@ -316,18 +332,24 @@ impl Statistics {
     fn classify_cycle(
         &self,
         gp_flag: bool,
-        register_value_diffs: &FxHashMap<RegisterId, u64>,
+        register_value_diffs: &Option<&FxHashMap<RegisterId, u64>>,
     ) -> CycleType {
-        let changed_registers = register_value_diffs.len();
+        let changed_registers =
+            if let Some(register_value_diffs) = register_value_diffs {
+                register_value_diffs.len()
+            } else {
+                0
+            };
         if gp_flag {
             CycleType::GroupOrPrimitive
         } else if changed_registers == 0 {
             CycleType::Other
         } else {
-            let updated_fsms_count = register_value_diffs
-                .keys()
-                .filter(|r| self.fsms.contains(*r))
-                .count();
+            let updated_fsms_count = if let Some(r) = register_value_diffs {
+                r.keys().filter(|r| self.fsms.contains(*r)).count()
+            } else {
+                0
+            };
             if updated_fsms_count == changed_registers {
                 CycleType::FsmUpdate
             } else if updated_fsms_count == 0 {

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -121,6 +121,8 @@ struct CellStatsOut {
     #[serde(serialize_with = "format_float")]
     pd_update: f64,
     #[serde(serialize_with = "format_float")]
+    mult_control: f64,
+    #[serde(serialize_with = "format_float")]
     other: f64,
 }
 
@@ -176,6 +178,7 @@ impl CellStats {
             self.get_type_percent(CycleType::GroupOrPrimitive);
         let fsm_update = self.get_type_percent(CycleType::FsmUpdate);
         let pd_update = self.get_type_percent(CycleType::PdUpdate);
+        let mult_control = self.get_type_percent(CycleType::MultControl);
         let other = self.get_type_percent(CycleType::Other);
 
         CellStatsOut {
@@ -189,6 +192,7 @@ impl CellStats {
             group_or_primitive,
             fsm_update,
             pd_update,
+            mult_control,
             other,
         }
     }

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -204,38 +204,29 @@ pub struct Statistics {
     group_to_stats: SecondaryMap<GroupId, GroupStats>,
     cell_to_stats: SecondaryMap<CellId, CellStats>,
     fsms: FxHashSet<RegisterId>,
-    pds: FxHashSet<RegisterId>,
 }
 
 impl Statistics {
     pub fn new(
         group_to_names: Vec<(GroupId, String)>,
-        cell_info: Vec<(
-            CellId,
-            String,
-            FxHashSet<RegisterId>,
-            FxHashSet<RegisterId>,
-        )>,
+        cell_info: Vec<(CellId, String, FxHashSet<RegisterId>)>,
     ) -> Self {
         let mut fsms: FxHashSet<RegisterId> = FxHashSet::default();
-        let mut pds: FxHashSet<RegisterId> = FxHashSet::default();
         let group_to_stats = SecondaryMap::from_iter(
             group_to_names
                 .into_iter()
                 .map(|(group_id, name)| (group_id, GroupStats::new(name))),
         );
-        for (_, _, f, p) in cell_info.iter() {
+        for (_, _, f) in cell_info.iter() {
             fsms.extend(f);
-            pds.extend(p);
         }
         let cell_to_stats = SecondaryMap::from_iter(cell_info.into_iter().map(
-            |(cell_id, name, fsms, pds)| (cell_id, CellStats::new(name, fsms)),
+            |(cell_id, name, fsms)| (cell_id, CellStats::new(name, fsms)),
         ));
         Self {
             group_to_stats,
             cell_to_stats,
             fsms,
-            pds,
         }
     }
 

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -95,20 +95,65 @@ struct CellStatsOut {
     other: f64,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum CycleType {
+    GroupOrPrimitive,
+    FsmUpdate,
+    PdUpdate,
+    Other,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CellStats {
+    name: String,
+    num_fsms: u32,
+    total_cycles: u64,
+    times_active: u64,
+    type_to_num_cycles: FxHashMap<CycleType, u64>,
+}
+
+impl CellStats {
+    pub fn new(name: String, num_fsms: u32) -> Self {
+        let mut s = Self {
+            name,
+            num_fsms,
+            total_cycles: 0,
+            times_active: 0,
+            type_to_num_cycles: FxHashMap::default(),
+        };
+        s.type_to_num_cycles.insert(CycleType::GroupOrPrimitive, 0);
+        s.type_to_num_cycles.insert(CycleType::FsmUpdate, 0);
+        s.type_to_num_cycles.insert(CycleType::PdUpdate, 0);
+        s.type_to_num_cycles.insert(CycleType::Other, 0);
+        s
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Statistics {
     group_to_stats: SecondaryMap<GroupId, GroupStats>,
-    // cell_to_stats: SecondaryMap<CellId, CellStats>,
+    cell_to_stats: SecondaryMap<CellId, CellStats>,
 }
 
 impl Statistics {
-    pub fn new(group_to_names: Vec<(GroupId, String)>) -> Self {
+    pub fn new(
+        group_to_names: Vec<(GroupId, String)>,
+        cell_info: Vec<(CellId, String, u32)>,
+    ) -> Self {
         let group_to_stats = SecondaryMap::from_iter(
             group_to_names
                 .into_iter()
                 .map(|(group_id, name)| (group_id, GroupStats::new(name))),
         );
-        Self { group_to_stats }
+        let cell_to_stats = SecondaryMap::from_iter(cell_info.into_iter().map(
+            |(cell_id, name, num_fsms)| {
+                (cell_id, CellStats::new(name, num_fsms))
+            },
+        ));
+        Self {
+            group_to_stats,
+            cell_to_stats,
+        }
     }
 
     pub fn update(

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -7,7 +7,7 @@ use serde::{Serialize, Serializer};
 use std::fs::File;
 use std::path::PathBuf;
 
-/// Output Group stats CSV table
+/// Output Group stats CSV table (fitted to `group-stats.csv`)
 #[derive(Debug, Clone, Serialize)]
 struct GroupStatsOut {
     name: String,
@@ -19,6 +19,7 @@ struct GroupStatsOut {
     can_static: bool,
 }
 
+/// Intermediate data for a group's statistics in order to produce GroupStatsOut
 #[derive(Debug, Clone, Default)]
 struct GroupStats {
     name: String,
@@ -26,7 +27,7 @@ struct GroupStats {
     total_cycles: u64,
     min: u64,
     max: u64,
-    // the start cycle of this "span", if there exists one.
+    /// the start cycle of this active "span", if there exists one.
     curr_start: Option<u64>,
 }
 
@@ -42,11 +43,13 @@ impl GroupStats {
         }
     }
 
+    /// Function to call to collect data when the activation period of the group starts.
     pub fn group_start(&mut self, cycle: u64) {
         assert!(self.curr_start.is_none());
         self.curr_start = Some(cycle);
     }
 
+    /// Function to call to collect data when the activation period of the group ends.
     pub fn group_end(&mut self, cycle: u64) {
         assert!(self.curr_start.is_some());
         let start = self.curr_start.unwrap();
@@ -78,6 +81,7 @@ impl GroupStats {
     }
 }
 
+/// Rounds and truncates the float at two decimal places
 fn format_float<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -87,7 +91,18 @@ where
     serializer.serialize_str(&s)
 }
 
-/// Output Cell stats CSV table
+/// Represents the classification of a cycle (to determine how "useful" it was) for cell statistics
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum CycleType {
+    /// A group or primitive was active in at least one leaf node
+    GroupOrPrimitive,
+    FsmUpdate,
+    PdUpdate,
+    MultControl,
+    Other,
+}
+
+/// Output Cell stats CSV table (fitted to `cell-stats.csv`)
 #[derive(Debug, Clone, Serialize)]
 struct CellStatsOut {
     name: String,
@@ -109,37 +124,21 @@ struct CellStatsOut {
     other: f64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum CycleType {
-    GroupOrPrimitive,
-    FsmUpdate,
-    PdUpdate,
-    MultControl,
-    Other,
-}
-
+/// Intermediate data for a group's statistics in order to produce CellStatsOut
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 struct CellStats {
     name: String,
     num_fsms: u32,
-    // fsms: FxHashSet<RegisterId>,
-    // pds: FxHashSet<RegisterId>,
     total_cycles: u64,
     times_active: u64,
     type_to_num_cycles: FxHashMap<CycleType, u64>,
 }
 
 impl CellStats {
-    pub fn new(
-        name: String,
-        fsms: FxHashSet<RegisterId>,
-        // pds: FxHashSet<RegisterId>,
-    ) -> Self {
+    pub fn new(name: String, fsms: FxHashSet<RegisterId>) -> Self {
         let mut s = Self {
             name,
             num_fsms: fsms.len() as u32,
-            // fsms,
-            // pds,
             total_cycles: 0,
             times_active: 0,
             type_to_num_cycles: FxHashMap::default(),
@@ -148,10 +147,13 @@ impl CellStats {
         s.type_to_num_cycles.insert(CycleType::FsmUpdate, 0);
         s.type_to_num_cycles.insert(CycleType::PdUpdate, 0);
         s.type_to_num_cycles.insert(CycleType::Other, 0);
-        println!("Cell stats: {s:?}");
         s
     }
 
+    /// Function to call to collect data on a cycle when the cell in question is active
+    /// NOTE: Different from groups, cells need to be analyzed for every cycle because the
+    /// CycleType can change based on the tree & the particular control register updates of that
+    /// cycle.
     pub fn active_cell(&mut self, cycle_type: CycleType, started_now: bool) {
         self.type_to_num_cycles.insert(
             cycle_type.clone(),
@@ -199,6 +201,7 @@ impl CellStats {
     }
 }
 
+/// Represents all statistics collected on groups/cells.
 #[derive(Debug, Clone, Default)]
 pub struct Statistics {
     group_to_stats: SecondaryMap<GroupId, GroupStats>,
@@ -260,8 +263,9 @@ impl Statistics {
         }
     }
 
+    /// Should be called after the last cycle of the trace in order to close
+    /// all active groups
     pub fn close(&mut self, to_close: &CurrentlyActive, cycle: u64) {
-        // close out all groups that are still active
         for ended_group in to_close.get_active_groups() {
             assert!(self.group_to_stats.get(*ended_group).is_some());
             self.group_to_stats[*ended_group].group_end(cycle);

--- a/tools/petal/src/statistics.rs
+++ b/tools/petal/src/statistics.rs
@@ -1,8 +1,8 @@
-use crate::design::{CellId, GroupId};
+use crate::design::{CellId, GroupId, RegisterId};
 use crate::timeline::CurrentlyActive;
 use anyhow::{Context, Ok, Result, anyhow};
 use cranelift_entity::SecondaryMap;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fs::File;
@@ -96,10 +96,11 @@ struct CellStatsOut {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-enum CycleType {
+pub enum CycleType {
     GroupOrPrimitive,
     FsmUpdate,
     PdUpdate,
+    MultControl,
     Other,
 }
 
@@ -107,16 +108,24 @@ enum CycleType {
 struct CellStats {
     name: String,
     num_fsms: u32,
+    // fsms: FxHashSet<RegisterId>,
+    // pds: FxHashSet<RegisterId>,
     total_cycles: u64,
     times_active: u64,
     type_to_num_cycles: FxHashMap<CycleType, u64>,
 }
 
 impl CellStats {
-    pub fn new(name: String, num_fsms: u32) -> Self {
+    pub fn new(
+        name: String,
+        fsms: FxHashSet<RegisterId>,
+        // pds: FxHashSet<RegisterId>,
+    ) -> Self {
         let mut s = Self {
             name,
-            num_fsms,
+            num_fsms: fsms.len() as u32,
+            // fsms,
+            // pds,
             total_cycles: 0,
             times_active: 0,
             type_to_num_cycles: FxHashMap::default(),
@@ -127,32 +136,87 @@ impl CellStats {
         s.type_to_num_cycles.insert(CycleType::Other, 0);
         s
     }
+
+    pub fn active_cell(&mut self, cycle_type: CycleType, started_now: bool) {
+        self.type_to_num_cycles.insert(
+            cycle_type.clone(),
+            self.type_to_num_cycles[&cycle_type] + 1,
+        );
+        self.total_cycles += 1;
+        if started_now {
+            self.times_active += 1;
+        }
+    }
+
+    pub fn convert_to_csv_struct(&self) -> CellStatsOut {
+        let avg = self.num_fsms as f64 / self.total_cycles as f64;
+        let useful_cycles = self.type_to_num_cycles
+            [&CycleType::GroupOrPrimitive]
+            + self.type_to_num_cycles[&CycleType::Other];
+        let useful_cycles_percent =
+            (useful_cycles as f64) / (self.total_cycles as f64);
+        let group_or_primitive =
+            self.get_type_percent(CycleType::GroupOrPrimitive);
+        let fsm_update = self.get_type_percent(CycleType::FsmUpdate);
+        let pd_update = self.get_type_percent(CycleType::PdUpdate);
+        let other = self.get_type_percent(CycleType::Other);
+
+        CellStatsOut {
+            name: self.name.clone(),
+            num_fsms: self.num_fsms,
+            total_cycles: self.total_cycles,
+            avg,
+            times_active: self.times_active,
+            useful_cycles,
+            useful_cycles_percent,
+            group_or_primitive,
+            fsm_update,
+            pd_update,
+            other,
+        }
+    }
+}
+
+impl CellStats {
+    fn get_type_percent(&self, t: CycleType) -> f64 {
+        let count = self.type_to_num_cycles[&t] as f64;
+        count / self.total_cycles as f64
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct Statistics {
     group_to_stats: SecondaryMap<GroupId, GroupStats>,
     cell_to_stats: SecondaryMap<CellId, CellStats>,
+    fsms: FxHashSet<RegisterId>,
+    pds: FxHashSet<RegisterId>,
 }
 
 impl Statistics {
     pub fn new(
         group_to_names: Vec<(GroupId, String)>,
-        cell_info: Vec<(CellId, String, u32)>,
+        cell_info: Vec<(
+            CellId,
+            String,
+            FxHashSet<RegisterId>,
+            FxHashSet<RegisterId>,
+        )>,
     ) -> Self {
+        let fsms: FxHashSet<RegisterId> = FxHashSet::default();
+        let pds: FxHashSet<RegisterId> = FxHashSet::default();
         let group_to_stats = SecondaryMap::from_iter(
             group_to_names
                 .into_iter()
                 .map(|(group_id, name)| (group_id, GroupStats::new(name))),
         );
         let cell_to_stats = SecondaryMap::from_iter(cell_info.into_iter().map(
-            |(cell_id, name, num_fsms)| {
-                (cell_id, CellStats::new(name, num_fsms))
-            },
+            |(cell_id, name, fsms, pds)| (cell_id, CellStats::new(name, fsms)),
         ));
         Self {
             group_to_stats,
             cell_to_stats,
+            fsms,
+            pds,
         }
     }
 
@@ -161,6 +225,9 @@ impl Statistics {
         started: &CurrentlyActive,
         ended: &CurrentlyActive,
         cycle: u64,
+        gp_flag: bool,
+        register_value_diffs: &FxHashMap<u64, FxHashMap<RegisterId, u64>>,
+        active_cells: &FxHashSet<CellId>,
     ) {
         // process all groups that started
         for started_group in started.get_active_groups() {
@@ -173,9 +240,57 @@ impl Statistics {
             assert!(self.group_to_stats.get(*ended_group).is_some());
             self.group_to_stats[*ended_group].group_end(cycle);
         }
+
+        let cycle_type =
+            self.classify_cycle(gp_flag, &register_value_diffs[&cycle]);
+        for cell in active_cells {
+            let started_now = started.get_active_cells().contains(cell);
+            self.cell_to_stats[*cell]
+                .active_cell(cycle_type.clone(), started_now);
+        }
+    }
+
+    pub fn close(&mut self, to_close: &CurrentlyActive, cycle: u64) {
+        // close out all groups that are still active
+        for ended_group in to_close.get_active_groups() {
+            assert!(self.group_to_stats.get(*ended_group).is_some());
+            self.group_to_stats[*ended_group].group_end(cycle);
+        }
     }
 
     pub fn output(&self, out_dir: &str) -> Result<()> {
+        self.output_group(out_dir)?;
+        self.output_cell(out_dir)?;
+        Ok(())
+    }
+}
+
+impl Statistics {
+    fn output_cell(&self, out_dir: &str) -> Result<()> {
+        let mut path = PathBuf::from(out_dir);
+        path.push("cell-stats.csv");
+        let file = File::create(path)?;
+
+        let mut writer = csv::Writer::from_writer(file);
+        // serialize in sorted order of cell name
+        let name_to_stats_csv: FxHashMap<String, CellStatsOut> = self
+            .cell_to_stats
+            .iter()
+            .map(|(_, stats)| {
+                (stats.name.clone(), stats.convert_to_csv_struct())
+            })
+            .collect();
+        let mut sorted_names: Vec<String> =
+            name_to_stats_csv.keys().cloned().collect();
+        sorted_names.sort();
+        for name in sorted_names {
+            writer.serialize(name_to_stats_csv[&name].clone())?;
+        }
+
+        Ok(())
+    }
+
+    fn output_group(&self, out_dir: &str) -> Result<()> {
         let mut path = PathBuf::from(out_dir);
         path.push("group-stats.csv");
         let file = File::create(path)?;
@@ -196,5 +311,30 @@ impl Statistics {
             writer.serialize(name_to_stats_csv[&name].clone())?;
         }
         Ok(())
+    }
+
+    fn classify_cycle(
+        &self,
+        gp_flag: bool,
+        register_value_diffs: &FxHashMap<RegisterId, u64>,
+    ) -> CycleType {
+        let changed_registers = register_value_diffs.len();
+        if gp_flag {
+            CycleType::GroupOrPrimitive
+        } else if changed_registers == 0 {
+            CycleType::Other
+        } else {
+            let updated_fsms_count = register_value_diffs
+                .keys()
+                .filter(|r| self.fsms.contains(*r))
+                .count();
+            if updated_fsms_count == changed_registers {
+                CycleType::FsmUpdate
+            } else if updated_fsms_count == 0 {
+                CycleType::PdUpdate
+            } else {
+                CycleType::MultControl
+            }
+        }
     }
 }

--- a/tools/petal/src/timeline.rs
+++ b/tools/petal/src/timeline.rs
@@ -6,7 +6,6 @@ use crate::perfetto_protos::track_descriptor::StaticOrDynamicName;
 use crate::perfetto_protos::track_event::{NameField, Type};
 use crate::perfetto_protos::{Trace, TracePacket, TrackDescriptor, TrackEvent};
 use anyhow::{Ok, Result};
-use cranelift_entity::SecondaryMap;
 use prost::Message;
 use prost::bytes::BytesMut;
 use rustc_hash::{FxHashMap, FxHashSet};

--- a/tools/petal/src/timeline.rs
+++ b/tools/petal/src/timeline.rs
@@ -244,9 +244,9 @@ impl Timeline {
         cycle_count: u64,
     ) -> Result<()> {
         // register all end events
-        self.update_helper(&ended, cycle_count, Type::SliceEnd);
+        self.update_helper(ended, cycle_count, Type::SliceEnd);
         // register all start events
-        self.update_helper(&started, cycle_count, Type::SliceBegin);
+        self.update_helper(started, cycle_count, Type::SliceBegin);
         Ok(())
     }
 }

--- a/tools/petal/src/timeline.rs
+++ b/tools/petal/src/timeline.rs
@@ -66,7 +66,7 @@ impl CurrentlyActive {
     }
 
     /// Results the diffs between existing active cells/control/groups vs active cells/control/groups
-    /// Returns (Ended cells/control/groups, Started cells/control/groups)
+    /// Returns (Started cells/control/groups, Ended cells/control/groups).
     pub fn resolve(&self, new: &Self) -> Result<(Self, Self)> {
         let ended = Self {
             groups: self.groups.difference(&new.groups).copied().collect(),
@@ -78,7 +78,7 @@ impl CurrentlyActive {
             cells: new.cells.difference(&self.cells).copied().collect(),
             control: new.control.difference(&self.control).copied().collect(),
         };
-        Ok((ended, started))
+        Ok((started, ended))
     }
 }
 
@@ -238,16 +238,16 @@ impl Timeline {
     }
 
     /// Adds events for cells/control/groups that started or ended.
-    pub fn update_timeline(
+    pub fn update(
         &mut self,
         started: &CurrentlyActive,
         ended: &CurrentlyActive,
         cycle_count: u64,
     ) -> Result<()> {
         // register all end events
-        self.update(&ended, cycle_count, Type::SliceEnd);
+        self.update_helper(&ended, cycle_count, Type::SliceEnd);
         // register all start events
-        self.update(&started, cycle_count, Type::SliceBegin);
+        self.update_helper(&started, cycle_count, Type::SliceBegin);
         Ok(())
     }
 }
@@ -256,7 +256,7 @@ impl Timeline {
     /// Helper function of update_timeline.
     /// Updates the timeline based on the diff of active cells/groups/control between
     /// the previous cycle and this cycle.
-    fn update(
+    fn update_helper(
         &mut self,
         diff: &CurrentlyActive,
         cycle_count: u64,

--- a/tools/petal/src/timeline.rs
+++ b/tools/petal/src/timeline.rs
@@ -6,6 +6,7 @@ use crate::perfetto_protos::track_descriptor::StaticOrDynamicName;
 use crate::perfetto_protos::track_event::{NameField, Type};
 use crate::perfetto_protos::{Trace, TracePacket, TrackDescriptor, TrackEvent};
 use anyhow::{Ok, Result};
+use cranelift_entity::SecondaryMap;
 use prost::Message;
 use prost::bytes::BytesMut;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -56,6 +57,14 @@ impl CurrentlyActive {
         self.control.insert(control);
     }
 
+    pub fn get_active_groups(&self) -> &FxHashSet<GroupId> {
+        &self.groups
+    }
+
+    pub fn get_active_cells(&self) -> &FxHashSet<CellId> {
+        &self.cells
+    }
+
     /// Results the diffs between existing active cells/control/groups vs active cells/control/groups
     /// Returns (Ended cells/control/groups, Started cells/control/groups)
     pub fn resolve(&self, new: &Self) -> Result<(Self, Self)> {
@@ -94,7 +103,6 @@ pub struct Timeline {
     control_to_info: FxHashMap<ControlId, TrackEventInfo>,
     group_to_info: FxHashMap<GroupId, TrackEventInfo>,
     register_to_uuid: FxHashMap<RegisterId, Uuid>,
-    current_active: CurrentlyActive,
 }
 
 impl Timeline {
@@ -106,7 +114,6 @@ impl Timeline {
             control_to_info: FxHashMap::default(),
             group_to_info: FxHashMap::default(),
             register_to_uuid: FxHashMap::default(),
-            current_active: CurrentlyActive::new(),
         };
         Ok(s)
     }
@@ -230,21 +237,17 @@ impl Timeline {
         Ok(())
     }
 
-    /// Takes the diff between the current cells/control/groups that are active and those that
-    /// are active in this new cycle, then adds events for those that started or ended.
+    /// Adds events for cells/control/groups that started or ended.
     pub fn update_timeline(
         &mut self,
-        active_this_cycle: &CurrentlyActive,
+        started: &CurrentlyActive,
+        ended: &CurrentlyActive,
         cycle_count: u64,
     ) -> Result<()> {
-        let (ended, started) =
-            self.current_active.resolve(active_this_cycle)?;
         // register all end events
         self.update(&ended, cycle_count, Type::SliceEnd);
         // register all start events
         self.update(&started, cycle_count, Type::SliceBegin);
-
-        self.current_active = active_this_cycle.clone();
         Ok(())
     }
 }

--- a/tools/petal/src/visuals.rs
+++ b/tools/petal/src/visuals.rs
@@ -16,7 +16,8 @@ pub struct FlameCount {
 pub fn compute_flame(stacks: &Stacks) -> Result<Vec<(String, FlameCount)>> {
     let mut out = IndexMap::<String, FlameCount>::with_capacity(stacks.len());
     // now we only look at the stacks for each unique value
-    for (count, stacks, _) in stacks.values().filter(|(_, s, _)| !s.is_empty())
+    for (count, stacks, _, _) in
+        stacks.values().filter(|(_, s, _, _)| !s.is_empty())
     {
         let factor = *count as f64;
         let mut stack_strings: Vec<String> =

--- a/tools/petal/test/language-tutorial-iterate.expect
+++ b/tools/petal/test/language-tutorial-iterate.expect
@@ -1,12 +1,3 @@
-main;tdcc ~ L68:seq (ctrl) 3
-main;tdcc ~ L68:seq (ctrl);cond;lt (primitive) 9
-main;tdcc ~ L68:seq (ctrl);incr;add2 (primitive) 8
-main;tdcc ~ L68:seq (ctrl);incr;counter (primitive) 8
-main;tdcc ~ L68:seq (ctrl);init;counter (primitive) 1
-main;tdcc ~ L68:seq (ctrl);read;val (primitive) 8
-main;tdcc ~ L68:seq (ctrl);upd;add (primitive) 8
-main;tdcc ~ L68:seq (ctrl);upd;val (primitive) 8
-main;tdcc ~ L68:seq (ctrl);write;mem (primitive) 8
 =========
 name,num_times_active,total_cycles,min,max,avg,can_static
 main.cond,9,9,1,1,1.0,true
@@ -16,5 +7,5 @@ main.read,8,8,1,1,1.0,true
 main.upd,8,8,1,1,1.0,true
 main.write,8,8,1,1,1.0,true
 =========
-name,num_fsms,total_cycles,times_active,avg,useful_cycles,useful_cycles_percent,group_or_primitive,fsm_update,pd_update,other
-main [main],1,37,1,37.00,34,91.89,91.89,8.11,0.00,0.00
+---STDERR---
+sort: No such file or directory

--- a/tools/petal/test/language-tutorial-iterate.expect
+++ b/tools/petal/test/language-tutorial-iterate.expect
@@ -15,3 +15,6 @@ main.init,1,1,1,1,1.0,true
 main.read,8,8,1,1,1.0,true
 main.upd,8,8,1,1,1.0,true
 main.write,8,8,1,1,1.0,true
+=========
+name,num_fsms,total_cycles,times_active,avg,useful_cycles,useful_cycles_percent,group_or_primitive,fsm_update,pd_update,other
+main [main],1,37,1,37.00,34,91.89,91.89,8.11,0.00,0.00

--- a/tools/petal/test/language-tutorial-iterate.expect
+++ b/tools/petal/test/language-tutorial-iterate.expect
@@ -7,3 +7,11 @@ main;tdcc ~ L68:seq (ctrl);read;val (primitive) 8
 main;tdcc ~ L68:seq (ctrl);upd;add (primitive) 8
 main;tdcc ~ L68:seq (ctrl);upd;val (primitive) 8
 main;tdcc ~ L68:seq (ctrl);write;mem (primitive) 8
+=========
+name,num_times_active,total_cycles,min,max,avg,can_static
+main.cond,9,9,1,1,1.0,true
+main.incr,8,8,1,1,1.0,true
+main.init,1,1,1,1,1.0,true
+main.read,8,8,1,1,1.0,true
+main.upd,8,8,1,1,1.0,true
+main.write,8,8,1,1,1.0,true

--- a/tools/petal/test/pipelined-mac.expect
+++ b/tools/petal/test/pipelined-mac.expect
@@ -42,3 +42,7 @@ pipelined_mac.stage2,10,10,1,1,1.0,true
 pipelined_mac.unset_out_valid,1,1,1,1,1.0,true
 pipelined_mac.unset_stage2_valid,1,1,1,1,1.0,true
 pipelined_mac.write_data_valid,11,11,1,1,1.0,true
+=========
+name,num_fsms,total_cycles,times_active,avg,useful_cycles,useful_cycles_percent,group_or_primitive,fsm_update,pd_update,other
+main [main],1,92,1,92.00,88,95.65,92.39,4.35,0.00,3.26
+main.mac [pipelined_mac],0,66,11,6.00,66,100.00,95.45,0.00,0.00,4.55

--- a/tools/petal/test/pipelined-mac.expect
+++ b/tools/petal/test/pipelined-mac.expect
@@ -24,3 +24,21 @@ main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];write_data_valid;dat
 main;tdcc ~ L156:seq (ctrl);save_out;out (primitive) 1
 main;tdcc ~ L156:seq (ctrl);store_a;read_a (primitive) 10
 main;tdcc ~ L156:seq (ctrl);store_b;read_b (primitive) 10
+=========
+name,num_times_active,total_cycles,min,max,avg,can_static
+main.in_range,10,10,1,1,1.0,true
+main.incr_idx,9,9,1,1,1.0,true
+main.init_all,1,1,1,1,1.0,true
+main.invoke_mac0,1,6,6,6,0.16666666666666666,true
+main.invoke_mac1,9,54,6,6,0.16666666666666666,true
+main.invoke_mac2,1,6,6,6,0.16666666666666666,true
+main.save_out,1,1,1,1,1.0,true
+main.store_a,9,9,1,1,1.0,true
+main.store_b,9,9,1,1,1.0,true
+pipelined_mac.set_out_valid,10,10,1,1,1.0,true
+pipelined_mac.set_stage2_valid,10,10,1,1,1.0,true
+pipelined_mac.stage1,10,40,4,4,0.25,true
+pipelined_mac.stage2,10,10,1,1,1.0,true
+pipelined_mac.unset_out_valid,1,1,1,1,1.0,true
+pipelined_mac.unset_stage2_valid,1,1,1,1,1.0,true
+pipelined_mac.write_data_valid,11,11,1,1,1.0,true

--- a/tools/petal/test/pipelined-mac.expect
+++ b/tools/petal/test/pipelined-mac.expect
@@ -1,29 +1,3 @@
-main;tdcc ~ L156:seq (ctrl) 4
-main;tdcc ~ L156:seq (ctrl);in_range;lt0 (primitive) 10
-main;tdcc ~ L156:seq (ctrl);incr_idx;add0 (primitive) 10
-main;tdcc ~ L156:seq (ctrl);incr_idx;idx0 (primitive) 10
-main;tdcc ~ L156:seq (ctrl);init_all;idx0 (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];set_stage2_valid;stage2_valid (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];stage1;mult_pipe (primitive) 3
-main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];stage1;pipe1 (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];unset_out_valid;out_valid (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac0;mac [pipelined_mac];write_data_valid;data_valid_reg (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];set_out_valid;out_valid (primitive) 9
-main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];set_stage2_valid;stage2_valid (primitive) 9
-main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];stage1;mult_pipe (primitive) 27
-main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];stage1;pipe1 (primitive) 9
-main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];stage2;add (primitive) 9
-main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];stage2;pipe2 (primitive) 9
-main;tdcc ~ L156:seq (ctrl);invoke_mac1;mac [pipelined_mac];write_data_valid;data_valid_reg (primitive) 9
-main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac] 3
-main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];set_out_valid;out_valid (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];stage2;add (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];stage2;pipe2 (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];unset_stage2_valid;stage2_valid (primitive) 1
-main;tdcc ~ L156:seq (ctrl);invoke_mac2;mac [pipelined_mac];write_data_valid;data_valid_reg (primitive) 1
-main;tdcc ~ L156:seq (ctrl);save_out;out (primitive) 1
-main;tdcc ~ L156:seq (ctrl);store_a;read_a (primitive) 10
-main;tdcc ~ L156:seq (ctrl);store_b;read_b (primitive) 10
 =========
 name,num_times_active,total_cycles,min,max,avg,can_static
 main.in_range,10,10,1,1,1.0,true
@@ -43,6 +17,5 @@ pipelined_mac.unset_out_valid,1,1,1,1,1.0,true
 pipelined_mac.unset_stage2_valid,1,1,1,1,1.0,true
 pipelined_mac.write_data_valid,11,11,1,1,1.0,true
 =========
-name,num_fsms,total_cycles,times_active,avg,useful_cycles,useful_cycles_percent,group_or_primitive,fsm_update,pd_update,other
-main [main],1,92,1,92.00,88,95.65,92.39,4.35,0.00,3.26
-main.mac [pipelined_mac],0,66,11,6.00,66,100.00,95.45,0.00,0.00,4.55
+---STDERR---
+sort: No such file or directory

--- a/tools/petal/test/structural-enable-cond.expect
+++ b/tools/petal/test/structural-enable-cond.expect
@@ -1,8 +1,7 @@
-main;wr_b;wr_a;a (primitive) 1
 =========
 name,num_times_active,total_cycles,min,max,avg,can_static
 main.wr_a,1,1,1,1,1.0,true
 main.wr_b,1,1,1,1,1.0,true
 =========
-name,num_fsms,total_cycles,times_active,avg,useful_cycles,useful_cycles_percent,group_or_primitive,fsm_update,pd_update,other
-main [main],0,1,1,1.00,1,100.00,100.00,0.00,0.00,0.00
+---STDERR---
+sort: No such file or directory

--- a/tools/petal/test/structural-enable-cond.expect
+++ b/tools/petal/test/structural-enable-cond.expect
@@ -3,3 +3,6 @@ main;wr_b;wr_a;a (primitive) 1
 name,num_times_active,total_cycles,min,max,avg,can_static
 main.wr_a,1,1,1,1,1.0,true
 main.wr_b,1,1,1,1,1.0,true
+=========
+name,num_fsms,total_cycles,times_active,avg,useful_cycles,useful_cycles_percent,group_or_primitive,fsm_update,pd_update,other
+main [main],0,1,1,1.00,1,100.00,100.00,0.00,0.00,0.00

--- a/tools/petal/test/structural-enable-cond.expect
+++ b/tools/petal/test/structural-enable-cond.expect
@@ -1,1 +1,5 @@
 main;wr_b;wr_a;a (primitive) 1
+=========
+name,num_times_active,total_cycles,min,max,avg,can_static
+main.wr_a,1,1,1,1,1.0,true
+main.wr_b,1,1,1,1,1.0,true


### PR DESCRIPTION
This PR adds cell and group statistics tables to Rusted Petal! Now when running the `rusted-petal` fud2 op, the `<fud2_out_dir>/profiler-out` directory will contain `cell-stats.csv` and `group-stats.csv` files.