### PR TITLE
[Profiler] Fix corner case bugs in Rusted Petal

### DIFF
--- a/calyx/opt/src/passes_experimental/metadata_table_gen.rs
+++ b/calyx/opt/src/passes_experimental/metadata_table_gen.rs
@@ -1,8 +1,9 @@
 use crate::traversal::{Action, ConstructVisitor, Named, VisResult, Visitor};
 
 //use calyx_frontend::SetAttr::Pos;
-use calyx_ir::GetAttributes;
+use calyx_frontend::LibrarySignatures;
 use calyx_ir::source_info::{FileId, LineNum, SourceInfoTable};
+use calyx_ir::{Component, GetAttributes, StaticPar, StaticRepeat, StaticSeq};
 use calyx_utils::WithPos;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -192,6 +193,39 @@ impl Visitor for Metadata {
         _comp: &mut calyx_ir::Component,
         _sigs: &calyx_ir::LibrarySignatures,
         _comps: &[calyx_ir::Component],
+    ) -> VisResult {
+        self.add_control_node(s);
+        Ok(Action::Continue)
+    }
+
+    fn start_static_seq(
+        &mut self,
+        s: &mut StaticSeq,
+        _comp: &mut Component,
+        _sigs: &LibrarySignatures,
+        _comps: &[Component],
+    ) -> VisResult {
+        self.add_control_node(s);
+        Ok(Action::Continue)
+    }
+
+    fn start_static_par(
+        &mut self,
+        s: &mut StaticPar,
+        _comp: &mut Component,
+        _sigs: &LibrarySignatures,
+        _comps: &[Component],
+    ) -> VisResult {
+        self.add_control_node(s);
+        Ok(Action::Continue)
+    }
+
+    fn start_static_repeat(
+        &mut self,
+        s: &mut StaticRepeat,
+        _comp: &mut Component,
+        _sigs: &LibrarySignatures,
+        _comps: &[Component],
     ) -> VisResult {
         self.add_control_node(s);
         Ok(Action::Continue)

--- a/tools/petal/src/calyx_timeline.rs
+++ b/tools/petal/src/calyx_timeline.rs
@@ -69,6 +69,72 @@ impl CurrentlyActive {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct TrackZeroInfo {
+    uuid: Uuid,
+    occupant: Option<GroupId>,
+    backups: Vec<Uuid>,
+    backup_occupants: FxHashMap<Uuid, GroupId>,
+}
+
+impl TrackZeroInfo {
+    pub fn new(uuid: Uuid) -> Self {
+        Self {
+            uuid,
+            ..Default::default()
+        }
+    }
+
+    pub fn start_group(
+        &mut self,
+        t: &mut Timeline,
+        group: GroupId,
+    ) -> Result<Uuid> {
+        if self.occupant.is_some()
+            && self.backups.len() > self.backup_occupants.len()
+        {
+            // find the first unoccupied
+            let idx = self
+                .backups
+                .iter()
+                .position(|u| !self.backup_occupants.contains_key(u))
+                .unwrap();
+            let uuid = self.backups[idx];
+            self.backup_occupants.insert(uuid, group);
+            Ok(uuid)
+        } else if self.occupant.is_some() {
+            // all of the backups are occupied; create a new thread
+            let idx = self.backups.len();
+            let name = format!("Thread 000_{idx}");
+            let new_uuid = t.register_descriptor(name, Some(self.uuid))?;
+            self.backups.push(new_uuid);
+            self.backup_occupants.insert(new_uuid, group);
+            Ok(new_uuid)
+        } else {
+            assert!(self.occupant.is_none());
+            self.occupant = Some(group);
+            Ok(self.uuid)
+        }
+    }
+
+    pub fn end_group(&mut self, group: GroupId) -> Result<Uuid> {
+        if Some(group) == self.occupant {
+            self.occupant = None;
+            Ok(self.uuid)
+        } else {
+            let (u, _) = self
+                .backup_occupants
+                .iter()
+                .find(|(_, v)| **v == group)
+                .unwrap();
+
+            let uuid = *u;
+            self.backup_occupants.remove(&uuid);
+            Ok(uuid)
+        }
+    }
+}
+
 /// Constructs and outputs protobuf messages for constructing a timeline view.
 /// In the timeline, each component cell has a distinct track which contains tracks containing the
 /// group/control group/control register activity within that cell, organized as below:
@@ -81,6 +147,9 @@ pub struct CalyxTimeline {
     control_to_info: FxHashMap<ControlId, TrackEventInfo>,
     group_to_info: FxHashMap<GroupId, TrackEventInfo>,
     register_to_uuid: FxHashMap<RegisterId, Uuid>,
+    // accounting for the corner case where there are multiple groups mapped to the cell's
+    // track 0, but they are optimized to run in parallel
+    track_zero_to_backups: FxHashMap<Uuid, TrackZeroInfo>,
 }
 
 impl CalyxTimeline {
@@ -91,6 +160,7 @@ impl CalyxTimeline {
             control_to_info: FxHashMap::default(),
             group_to_info: FxHashMap::default(),
             register_to_uuid: FxHashMap::default(),
+            track_zero_to_backups: FxHashMap::default(),
         };
         Ok(s)
     }
@@ -142,6 +212,12 @@ impl CalyxTimeline {
                         .timeline
                         .register_descriptor(thread_name, Some(uuid))?;
                     thread_tracks.insert(*thread, thread_uuid);
+                    if *thread == 0 {
+                        self.track_zero_to_backups.insert(
+                            thread_uuid,
+                            TrackZeroInfo::new(thread_uuid),
+                        );
+                    }
                 }
             }
         }
@@ -201,9 +277,9 @@ impl CalyxTimeline {
         cycle_count: u64,
     ) -> Result<()> {
         // register all end events
-        self.update_helper(ended, cycle_count, Type::SliceEnd);
+        self.update_helper(ended, cycle_count, Type::SliceEnd)?;
         // register all start events
-        self.update_helper(started, cycle_count, Type::SliceBegin);
+        self.update_helper(started, cycle_count, Type::SliceBegin)?;
         Ok(())
     }
 
@@ -233,7 +309,7 @@ impl CalyxTimeline {
         diff: &CurrentlyActive,
         cycle_count: u64,
         event_type: Type,
-    ) {
+    ) -> Result<()> {
         for &cell in diff.cells.iter() {
             let TrackEventInfo { uuid, name } =
                 self.cell_to_info.get(&cell).unwrap();
@@ -259,13 +335,29 @@ impl CalyxTimeline {
         for &group in diff.groups.iter() {
             let TrackEventInfo { uuid, name } =
                 self.group_to_info.get(&group).unwrap();
+            let real_uuid: Uuid =
+                if let Some(tz) = self.track_zero_to_backups.get_mut(uuid) {
+                    match event_type {
+                        Type::SliceBegin => {
+                            tz.start_group(&mut self.timeline, group)?
+                        }
+                        Type::SliceEnd => tz.end_group(group)?,
+                        _ => {
+                            panic!("Unexpected event type")
+                        }
+                    }
+                } else {
+                    *uuid
+                };
             self.timeline.register_event(
                 name.clone(),
-                *uuid,
+                real_uuid,
                 cycle_count,
                 event_type,
             );
         }
+
+        Ok(())
     }
 }
 

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -1,4 +1,4 @@
-use anyhow::{Ok, Result, anyhow};
+use anyhow::{Ok, Result};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use std::{

--- a/tools/petal/src/control.rs
+++ b/tools/petal/src/control.rs
@@ -125,16 +125,13 @@ impl ControlInfo {
         self.pd.get(c).unwrap()
     }
 
-    pub fn get_pretty(&self, pos_set: &BTreeSet<u32>) -> Result<(String, u32)> {
+    pub fn get_pretty(&self, pos_set: &BTreeSet<u32>) -> Option<(String, u32)> {
         for pos in pos_set.iter() {
             if let Some(pretty) = self.pretty_map.get(pos) {
-                return Ok((pretty.clone(), *pos));
+                return Some((pretty.clone(), *pos));
             }
         }
-        Err(anyhow!(
-            "Positions in {:?} not found in pretty map",
-            pos_set
-        ))
+        None
     }
 
     pub fn get_tdcc(&self, pos: u32) -> Result<Option<&Vec<TdccInfo>>> {

--- a/tools/petal/src/dahlia_design.rs
+++ b/tools/petal/src/dahlia_design.rs
@@ -11,11 +11,11 @@ use std::collections::VecDeque;
 use std::fs::File;
 use std::path::PathBuf;
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default, Ord, PartialOrd)]
 pub struct StatementId(u32);
 entity_impl!(StatementId, "statement");
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default, Ord, PartialOrd)]
 pub struct BlockId(u32);
 entity_impl!(BlockId, "block");
 
@@ -78,8 +78,11 @@ impl DahliaDesign {
         assert_eq!(components.len(), 1);
         let main_component = &components[0];
         assert_eq!(main_component.component, "main");
-        let mut info_to_statement: FxHashMap<(u64, String), StatementId> =
-            FxHashMap::default();
+        // sort by line numbers so that statements with earlier line numbers will be processed first
+        let mut linenum_to_init_info: FxHashMap<
+            u64,
+            (FxHashSet<GroupId>, String),
+        > = FxHashMap::default();
         for PosInfo {
             name,
             linenum,
@@ -87,7 +90,10 @@ impl DahliaDesign {
             ..
         } in main_component.groups.iter()
         {
-            // let line_contents = varname.split(" {").next().unwrap().to_string();
+            let group_id_set = &group_names_to_ids.get(name).unwrap();
+            // Start by assuming that each group will only have one enable in control?
+            assert_eq!(group_id_set.len(), 1);
+            let group_id = group_id_set.iter().next().unwrap();
             let line_contents = varname
                 .split("{")
                 .next()
@@ -96,60 +102,65 @@ impl DahliaDesign {
                 .next()
                 .unwrap()
                 .to_string();
-            let stmt_id = if let Some(id) =
-                info_to_statement.get(&(*linenum, (varname.clone())))
-            {
-                *id
-            } else {
-                // we haven't seen this line yet; if it's a block, we will add the block in as well.
-                if all_block_lines.contains(linenum) {
-                    let b = Block {
-                        line_num: *linenum,
-                        line: line_contents.clone(),
-                        parent: None,
-                    };
-                    all_blocks.insert(*linenum, out.blocks.push(b));
-                }
-                // register the statement
-                let s = Statement {
-                    line_num: *linenum,
-                    line: line_contents.clone(),
-                    ancestors: vec![],
-                    parent: None,
-                };
-                out.statements.push(s)
-            };
-            let group_id_set = &group_names_to_ids[name];
-            // Start by assuming that each group will only have one enable in control?
-            assert_eq!(group_id_set.len(), 1);
-            let group_id = group_id_set.iter().next().unwrap();
-            out.groups_to_statement.insert(*group_id, stmt_id);
-            info_to_statement.insert((*linenum, varname.clone()), stmt_id);
+
+            let (groups, _line_contents) = linenum_to_init_info
+                .entry(*linenum)
+                .or_insert((FxHashSet::default(), line_contents));
+            groups.insert(*group_id);
         }
-        // for each statement, construct the list of ancestors
-        // I think we need to do this later because parent blocks may be added later than the child stmt
-        for (_id, stmt) in out.statements.iter_mut() {
-            if let Some(ancestor_line_nums) = parent_map.get(&stmt.line_num) {
-                let ancestors: Vec<BlockId> =
-                    ancestor_line_nums.iter().map(|a| all_blocks[a]).collect();
-                stmt.parent = ancestors.last().copied();
-                stmt.ancestors = ancestors;
-            }
-        }
-        // get parents for each block
-        for (_id, block) in out.blocks.iter_mut() {
-            // a block's immediate parent is always itself, so we want to look for its parent.
-            block.parent = if let Some(pv) = parent_map.get(&block.line_num) {
-                if pv.len() > 1 {
-                    let parent_line = pv[pv.len() - 2];
-                    all_blocks.get(&parent_line).copied()
+
+        let mut sorted_line_nums =
+            (&linenum_to_init_info).keys().cloned().collect::<Vec<_>>();
+        sorted_line_nums.sort();
+
+        for line_num in sorted_line_nums {
+            let (group_ids, line) =
+                linenum_to_init_info.get(&line_num).unwrap();
+
+            // we haven't seen this line yet; if it's a block, we will add the block in as well.
+            if all_block_lines.contains(&line_num) {
+                // a block's immediate parent is always itself, so we want to look for its parent.
+                let parent = if let Some(pv) = parent_map.get(&line_num) {
+                    if pv.len() > 1 {
+                        let parent_line = pv[pv.len() - 2];
+                        all_blocks.get(&parent_line).copied()
+                    } else {
+                        None
+                    }
                 } else {
                     None
-                }
+                };
+                let b = Block {
+                    line_num,
+                    line: line.clone(),
+                    parent,
+                };
+                all_blocks.insert(line_num, out.blocks.push(b));
+            }
+            // compute parent and ancestors list for this statement
+            let (parent, ancestors) = if let Some(ancestor_line_nums) =
+                parent_map.get(&line_num)
+            {
+                let ancestors: Vec<BlockId> =
+                    ancestor_line_nums.iter().map(|a| all_blocks[a]).collect();
+                (ancestors.last().copied(), ancestors)
             } else {
-                None
+                (None, Vec::new())
             };
+            // register the statement
+            let s = Statement {
+                line_num,
+                line: line.clone(),
+                ancestors,
+                parent,
+            };
+            let stmt_id = out.statements.push(s);
+
+            for g in group_ids {
+                out.groups_to_statement.insert(*g, stmt_id);
+            }
         }
+
         Ok(out)
     }
 
@@ -405,7 +416,11 @@ impl DahliaTimeline {
             );
         }
 
-        for statement in diff.statements.iter() {
+        let mut sv: Vec<StatementId> =
+            diff.statements.iter().copied().collect();
+        sv.sort();
+
+        for statement in sv.iter() {
             let StatementTrackInfo { name, parent, uuid } =
                 self.statement_to_info.get(statement).unwrap();
             if let Some(uuid) = uuid {

--- a/tools/petal/src/dahlia_design.rs
+++ b/tools/petal/src/dahlia_design.rs
@@ -110,7 +110,7 @@ impl DahliaDesign {
         }
 
         let mut sorted_line_nums =
-            (&linenum_to_init_info).keys().cloned().collect::<Vec<_>>();
+            (linenum_to_init_info).keys().cloned().collect::<Vec<_>>();
         sorted_line_nums.sort();
 
         for line_num in sorted_line_nums {

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -711,9 +711,10 @@ impl Design {
                 );
                 continue;
             }
-            let (pretty, pos) = c.get_pretty(pos_set)?;
+            if let Some((pretty, pos)) = c.get_pretty(pos_set) &&
             // any pos without an entry in tdcc was compiled away; we ignore these.
-            if let Some(tdcc_info_vec) = c.get_tdcc(pos)? {
+            let Some(tdcc_info_vec) = c.get_tdcc(pos)?
+            {
                 // pos is the entry to the Calyx-generated position of the control node,
                 // so there should only be one entry in the Vector.
                 assert_eq!(tdcc_info_vec.len(), 1);
@@ -740,6 +741,10 @@ impl Design {
                 let ctrl_id = self.controls.push(ctrl);
                 pos_to_id.insert(pos, ctrl_id);
                 descriptor_to_id.insert(d.clone(), ctrl_id);
+            } else {
+                println!(
+                    "Could not find control group for position set {pos_set:?}"
+                );
             }
         }
 

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -12,7 +12,7 @@ use crate::shared_cells::SharedCellsInfo;
 use crate::visuals::perfetto_protos::track_event::Type;
 use crate::visuals::timeline::Uuid;
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct CellId(u32);
 entity_impl!(CellId, "cell");
 
@@ -71,7 +71,7 @@ impl Cell {
     }
 }
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct GroupId(u32);
 entity_impl!(GroupId, "group");
 
@@ -102,7 +102,7 @@ impl Group {
     }
 }
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct ControlId(u32);
 entity_impl!(ControlId, "control");
 
@@ -704,6 +704,13 @@ impl Design {
 
         // iterate through control par descriptors and construct Control nodes
         for (d, pos_set) in descriptors.control_pos.iter() {
+            if pos_set.is_empty() {
+                // if the pos_set for a descriptor is empty, it's not a real control descriptor
+                println!(
+                    "Skipping descriptor with empty pos set (static control; will not manifest in a control group): {d}"
+                );
+                continue;
+            }
             let (pretty, pos) = c.get_pretty(pos_set)?;
             // any pos without an entry in tdcc was compiled away; we ignore these.
             if let Some(tdcc_info_vec) = c.get_tdcc(pos)? {


### PR DESCRIPTION
Some corner case bugs found and fixed:
- Perfetto UI has difficulty visualizing event spans that occur on the same track. When a event above other(s) ends first, all other events below it also look like they terminate. In Petal, if groups that are on "Thread 0" (not in a `par` block) later get optimized by a compiler pass to run concurrently, it could seem like some of the groups terminate earlier than expected because of this.
  - To circumvent this situation, Rusted Petal now creates multiple additional tracks for "Thread 0" (ex. `Thread 000_0`, `Thread 000_1`...).
- In Dahlia Profiling, if multiple statements started at the same time I made it so that the next available thread is taken by the statement that shows up earliest in the program.
- The `metadata_table_gen` pass did't produce `@pos` for static control nodes.