### PR TITLE
[Profiler] Avoid timeline OOM errors by writing one packet at a time

### DIFF
--- a/tools/petal/src/adls.rs
+++ b/tools/petal/src/adls.rs
@@ -151,11 +151,4 @@ impl AdlIntermediateInfo {
             AdlIntermediateInfo::Dahlia(d) => d.output_flame(out_dir),
         }
     }
-
-    pub fn output_timeline(self, out_dir: &str) -> Result<()> {
-        match self {
-            AdlIntermediateInfo::Py(_) => Ok(()),
-            AdlIntermediateInfo::Dahlia(d) => d.output_timeline(out_dir),
-        }
-    }
 }

--- a/tools/petal/src/adls.rs
+++ b/tools/petal/src/adls.rs
@@ -87,6 +87,7 @@ impl AdlIntermediateInfo {
         adl_filename: &str,
         dahlia_parent_file: Option<String>,
         d: &mut Design,
+        out_dir: &str,
     ) -> Result<Self> {
         let adl_file = File::open(adl_filename)?;
         let AdlInfo {
@@ -112,6 +113,7 @@ impl AdlIntermediateInfo {
                     components,
                     dahlia_parent_file,
                     d,
+                    out_dir,
                 )?;
                 Ok(Self::Dahlia(dpi))
             }

--- a/tools/petal/src/calyx_timeline.rs
+++ b/tools/petal/src/calyx_timeline.rs
@@ -153,9 +153,9 @@ pub struct CalyxTimeline {
 }
 
 impl CalyxTimeline {
-    pub fn new() -> Result<Self> {
+    pub fn new(out_dir: &str) -> Result<Self> {
         let s = Self {
-            timeline: Timeline::new(),
+            timeline: Timeline::new(out_dir, "timeline_trace.pftrace")?,
             cell_to_info: FxHashMap::default(),
             control_to_info: FxHashMap::default(),
             group_to_info: FxHashMap::default(),
@@ -318,7 +318,7 @@ impl CalyxTimeline {
                 *uuid,
                 cycle_count,
                 event_type,
-            );
+            )?;
         }
 
         for &control in diff.control.iter() {
@@ -329,7 +329,7 @@ impl CalyxTimeline {
                 *uuid,
                 cycle_count,
                 event_type,
-            );
+            )?;
         }
 
         for &group in diff.groups.iter() {

--- a/tools/petal/src/calyx_timeline.rs
+++ b/tools/petal/src/calyx_timeline.rs
@@ -289,14 +289,9 @@ impl CalyxTimeline {
         uuid: Uuid,
         timestamp: u64,
         event_type: Type,
-    ) {
+    ) -> Result<()> {
         self.timeline
-            .register_event(name, uuid, timestamp, event_type);
-    }
-
-    pub fn output_timeline(self, out_dir: &str) -> anyhow::Result<()> {
-        self.timeline
-            .output_timeline(out_dir, "timeline_trace.pftrace")
+            .register_event(name, uuid, timestamp, event_type)
     }
 }
 
@@ -354,7 +349,7 @@ impl CalyxTimeline {
                 real_uuid,
                 cycle_count,
                 event_type,
-            );
+            )?;
         }
 
         Ok(())

--- a/tools/petal/src/dahlia_design.rs
+++ b/tools/petal/src/dahlia_design.rs
@@ -395,11 +395,6 @@ impl DahliaTimeline {
         Ok(())
     }
 
-    pub fn output_timeline(self, out_dir: &str) -> Result<()> {
-        self.timeline
-            .output_timeline(out_dir, "dahlia_timeline_trace.pftrace")
-    }
-
     fn update_helper(
         &mut self,
         diff: &DahliaCurrentlyActive,
@@ -414,7 +409,7 @@ impl DahliaTimeline {
                 *uuid,
                 cycle_count,
                 event_type,
-            );
+            )?;
         }
 
         let mut sv: Vec<StatementId> =
@@ -430,7 +425,7 @@ impl DahliaTimeline {
                     *uuid,
                     cycle_count,
                     event_type,
-                );
+                )?;
             } else if let Some(parent) = parent {
                 // need to find the uuid using the parent
                 let parent_block = self.block_to_info.get_mut(parent).unwrap();
@@ -450,7 +445,7 @@ impl DahliaTimeline {
                     uuid,
                     cycle_count,
                     event_type,
-                );
+                )?;
             }
         }
         Ok(())
@@ -523,10 +518,6 @@ impl DahliaProfilingInfo {
         flat_flame.push("dahlia-flat-flame.folded");
         write_flames(&flame, Some(scaled_flame), Some(flat_flame))?;
         Ok(())
-    }
-
-    pub fn output_timeline(self, out_dir: &str) -> Result<()> {
-        self.timeline.output_timeline(out_dir)
     }
 }
 

--- a/tools/petal/src/dahlia_design.rs
+++ b/tools/petal/src/dahlia_design.rs
@@ -296,7 +296,7 @@ struct StatementTrackInfo {
     uuid: Option<Uuid>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug)]
 struct DahliaTimeline {
     timeline: Timeline,
     statement_to_info: FxHashMap<StatementId, StatementTrackInfo>,
@@ -304,8 +304,9 @@ struct DahliaTimeline {
 }
 
 impl DahliaTimeline {
-    pub fn new(d: &DahliaDesign) -> Result<Self> {
-        let mut timeline = Timeline::new();
+    pub fn new(d: &DahliaDesign, out_dir: &str) -> Result<Self> {
+        let mut timeline =
+            Timeline::new(out_dir, "dahlia_timeline_trace.pftrace")?;
         // create "main" track
         let main_uuid =
             timeline.register_descriptor("main".to_string(), None)?;
@@ -470,9 +471,10 @@ impl DahliaProfilingInfo {
         components: Vec<ComponentInfo>,
         parent_file: Option<String>,
         d: &Design,
+        out_dir: &str,
     ) -> Result<Self> {
         let design = DahliaDesign::new(components, parent_file, d)?;
-        let timeline = DahliaTimeline::new(&design)?;
+        let timeline = DahliaTimeline::new(&design, out_dir)?;
         Ok(Self {
             design,
             timeline,

--- a/tools/petal/src/design.rs
+++ b/tools/petal/src/design.rs
@@ -391,13 +391,13 @@ impl Design {
                     uuid,
                     cycle,
                     Type::SliceBegin,
-                );
+                )?;
                 timeline.register_event(
                     out_str,
                     uuid,
                     cycle + 1,
                     Type::SliceEnd,
-                );
+                )?;
             }
         }
         Ok(())

--- a/tools/petal/src/main.rs
+++ b/tools/petal/src/main.rs
@@ -182,6 +182,7 @@ fn main() -> Result<()> {
             &adl_file,
             args.dahlia_parent_map,
             &mut design,
+            &args.out_dir,
         )?;
         Some(a)
     } else {
@@ -190,7 +191,7 @@ fn main() -> Result<()> {
 
     // create tracks in the timeline
     let par_tracks = calyx_timeline::read_par_tracks(args.par_tracks_filename)?;
-    let mut timeline = CalyxTimeline::new()?;
+    let mut timeline = CalyxTimeline::new(&args.out_dir)?;
     design.build_timeline_tracks(&mut timeline, &par_tracks)?;
     let mut statistics = build_statistics(&design)?;
 
@@ -303,12 +304,12 @@ fn main() -> Result<()> {
         &mut timeline,
         register_value_diffs,
     )?;
-    timeline.output_timeline(&args.out_dir)?;
+    // timeline.output_timeline(&args.out_dir)?;
     statistics.output(&args.out_dir)?;
 
     if let Some(mut adl_data) = adl_info {
         adl_data.output_flame(&args.out_dir)?;
-        adl_data.output_timeline(&args.out_dir)?;
+        // adl_data.output_timeline(&args.out_dir)?;
     }
 
     Ok(())

--- a/tools/petal/src/visuals/timeline.rs
+++ b/tools/petal/src/visuals/timeline.rs
@@ -1,3 +1,4 @@
+use crate::visuals::perfetto_protos;
 use crate::visuals::perfetto_protos::trace_packet::{
     Data, OptionalTrustedPacketSequenceId,
 };
@@ -6,10 +7,11 @@ use crate::visuals::perfetto_protos::track_event::{NameField, Type};
 use crate::visuals::perfetto_protos::{
     Trace, TracePacket, TrackDescriptor, TrackEvent,
 };
+use anyhow::Result;
 use prost::Message;
 use prost::bytes::BytesMut;
 use rustc_hash::FxHashSet;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
 
@@ -19,18 +21,27 @@ pub const TPSI: u32 = 8008;
 /// A unique identifier used for specifying tracks in the timeline.
 pub type Uuid = u64;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub(crate) struct Timeline {
     packets: Vec<TracePacket>,
     used_uuids: FxHashSet<u64>,
+    output_file: File,
 }
 
 impl Timeline {
-    pub fn new() -> Self {
-        Self {
+    pub fn new(
+        out_dir: &str,
+        out_file_name: &str, // "timeline_trace.pftrace"
+    ) -> Result<Self> {
+        let mut path = PathBuf::from(out_dir);
+        path.push(out_file_name);
+        // let mut file = File::create(path)?;
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
             packets: Vec::new(),
             used_uuids: FxHashSet::default(),
-        }
+            output_file: file,
+        })
     }
 
     /// Creates a new track in the timeline.
@@ -49,7 +60,8 @@ impl Timeline {
             ..Default::default()
         };
         let packet = create_packet_helper(0, Data::TrackDescriptor(descriptor));
-        self.packets.push(packet);
+        self.push_packet(packet)?;
+        // self.packets.push(packet);
         anyhow::Ok(uuid)
     }
 
@@ -60,7 +72,7 @@ impl Timeline {
         uuid: Uuid,
         timestamp: u64,
         event_type: Type,
-    ) {
+    ) -> Result<()> {
         let event = TrackEvent {
             name_field: Some(NameField::Name(name)),
             r#type: Some(event_type as i32),
@@ -68,7 +80,19 @@ impl Timeline {
             ..Default::default()
         };
         let packet = create_packet_helper(timestamp, Data::TrackEvent(event));
-        self.packets.push(packet);
+        self.push_packet(packet)
+    }
+
+    pub fn push_packet(&mut self, packet: TracePacket) -> Result<()> {
+        let trace = perfetto_protos::Trace {
+            packet: vec![packet],
+        };
+        // self.packets.push(packet);
+        let encoded_len = trace.encoded_len();
+        let mut buf = BytesMut::with_capacity(encoded_len);
+        trace.encode(&mut buf)?;
+        self.output_file.write_all(&buf)?;
+        Ok(())
     }
 
     pub fn output_timeline(

--- a/tools/petal/src/visuals/timeline.rs
+++ b/tools/petal/src/visuals/timeline.rs
@@ -33,7 +33,6 @@ impl Timeline {
     ) -> Result<Self> {
         let mut path = PathBuf::from(out_dir);
         path.push(out_file_name);
-        // let mut file = File::create(path)?;
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         Ok(Self {
             used_uuids: FxHashSet::default(),

--- a/tools/petal/src/visuals/timeline.rs
+++ b/tools/petal/src/visuals/timeline.rs
@@ -1,4 +1,3 @@
-use crate::visuals::perfetto_protos;
 use crate::visuals::perfetto_protos::trace_packet::{
     Data, OptionalTrustedPacketSequenceId,
 };
@@ -23,7 +22,6 @@ pub type Uuid = u64;
 
 #[derive(Debug)]
 pub(crate) struct Timeline {
-    packets: Vec<TracePacket>,
     used_uuids: FxHashSet<u64>,
     output_file: File,
 }
@@ -38,7 +36,6 @@ impl Timeline {
         // let mut file = File::create(path)?;
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         Ok(Self {
-            packets: Vec::new(),
             used_uuids: FxHashSet::default(),
             output_file: file,
         })
@@ -61,7 +58,6 @@ impl Timeline {
         };
         let packet = create_packet_helper(0, Data::TrackDescriptor(descriptor));
         self.push_packet(packet)?;
-        // self.packets.push(packet);
         anyhow::Ok(uuid)
     }
 
@@ -83,35 +79,17 @@ impl Timeline {
         self.push_packet(packet)
     }
 
+    /// Outputs a packet onto the timeline file. (We write packets one by one
+    /// to avoid an out-of-memory error.)
     pub fn push_packet(&mut self, packet: TracePacket) -> Result<()> {
-        let trace = perfetto_protos::Trace {
+        let trace = Trace {
             packet: vec![packet],
         };
-        // self.packets.push(packet);
         let encoded_len = trace.encoded_len();
         let mut buf = BytesMut::with_capacity(encoded_len);
         trace.encode(&mut buf)?;
         self.output_file.write_all(&buf)?;
         Ok(())
-    }
-
-    pub fn output_timeline(
-        self,
-        out_dir: &str,
-        out_file_name: &str, // "timeline_trace.pftrace"
-    ) -> anyhow::Result<()> {
-        // we can move self.packets because we will no longer add any information to it.
-        let trace = Trace {
-            packet: self.packets,
-        };
-        let encoded_len = trace.encoded_len();
-        let mut buf = BytesMut::with_capacity(encoded_len);
-        trace.encode(&mut buf)?;
-        let mut path = PathBuf::from(out_dir);
-        path.push(out_file_name);
-        let mut file = File::create(path)?;
-        file.write_all(&buf)?;
-        anyhow::Ok(())
     }
 }
 


### PR DESCRIPTION
This was a problem that we had in Python Petal as well but I completely forgot about it for the Rust reimplementation. (without this fix it could take 23GB of RAM to profile `strict-6flow-test`!!!)